### PR TITLE
Travis CI: Python flake8 tests can find undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,4 +40,11 @@ branches:
   only:
   - master
 
+before_script:
+  - pip install flake8
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
 script: travis_wait pytest tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,6 @@ matrix:
     - wget https://archive.ics.uci.edu/ml/machine-learning-databases/statlog/german/german.data -P aif360/data/raw/german/
     - wget https://archive.ics.uci.edu/ml/machine-learning-databases/statlog/german/german.doc -P aif360/data/raw/german/
     - wget https://raw.githubusercontent.com/propublica/compas-analysis/master/compas-scores-two-years.csv -P aif360/data/raw/compas/
-  exclude:
-  - python: "2.7"
-  - python: "3.6"
 
 branches:
   only:


### PR DESCRIPTION
Add [flake8](http://flake8.pycqa.org) tests to find Python syntax errors and undefined names.

__E901,E999,F821,F822,F823__ are the "_showstopper_" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree