### PR TITLE
Added algorithms and test file for Celis et al. paper.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Get in touch with us on [Slack](https://aif360.slack.com) (invitation [here](htt
 * Calibrated Equalized Odds Postprocessing ([Pleiss et al., 2017](https://papers.nips.cc/paper/7151-on-fairness-and-calibration))
 * Learning Fair Representations ([Zemel et al., 2013](http://proceedings.mlr.press/v28/zemel13.html))
 * Adversarial Debiasing ([Zhang et al., 2018](http://www.aies-conference.com/wp-content/papers/main/AIES_2018_paper_162.pdf))
+* Meta-Algorithm for Fair Classification ([Celis et al.. 2018](https://arxiv.org/abs/1806.06055))
 
 ## Supported fairness metrics
 

--- a/aif360/algorithms/inprocessing/__init__.py
+++ b/aif360/algorithms/inprocessing/__init__.py
@@ -1,3 +1,4 @@
 from aif360.algorithms.inprocessing.adversarial_debiasing import AdversarialDebiasing
 from aif360.algorithms.inprocessing.art_classifier import ARTClassifier
 from aif360.algorithms.inprocessing.prejudice_remover import PrejudiceRemover
+from aif360.algorithms.inprocessing.meta_fair_classifier import MetaFairClassifer

--- a/aif360/algorithms/inprocessing/__init__.py
+++ b/aif360/algorithms/inprocessing/__init__.py
@@ -1,4 +1,4 @@
 from aif360.algorithms.inprocessing.adversarial_debiasing import AdversarialDebiasing
 from aif360.algorithms.inprocessing.art_classifier import ARTClassifier
 from aif360.algorithms.inprocessing.prejudice_remover import PrejudiceRemover
-from aif360.algorithms.inprocessing.meta_fair_classifier import MetaFairClassifer
+from aif360.algorithms.inprocessing.meta_fair_classifier import MetaFairClassifier

--- a/aif360/algorithms/inprocessing/celisMeta/FalseDiscovery.py
+++ b/aif360/algorithms/inprocessing/celisMeta/FalseDiscovery.py
@@ -1,0 +1,146 @@
+import os,sys
+from scipy.stats import multivariate_normal
+import scipy.stats as st
+import numpy as np
+import math
+from General import *
+import utils as ut
+
+
+class FalseDiscovery(General):
+
+	def getExpectedGrad(self, dist_params, params, samples, mu,  z_0, z_1, a, b):
+		u_1, u_2, l_1, l_2 = params[0], params[1], params[2], params[3]
+		a, b = a[0], b[0]
+		res1 = []
+		res2 = []
+		res3 = []
+		res4 = []
+		for x in samples:
+				temp = np.append(np.append(x, 1), 1)
+				prob_1_1 = ut.getProbability(dist_params, temp)
+
+				temp = np.append(np.append(x, -1), 1)
+				prob_m1_1 = ut.getProbability(dist_params, temp)
+
+				temp = np.append(np.append(x, 1), 0)
+				prob_1_0 = ut.getProbability(dist_params, temp)
+
+				temp = np.append(np.append(x, -1), 0)
+				prob_m1_0 = ut.getProbability(dist_params, temp)
+
+
+				prob_y_1 = (prob_1_1 + prob_1_0) / (prob_1_1 + prob_1_0 + prob_m1_0 + prob_m1_1)
+				#print(prob_y_1)
+
+				prob_z_0 = (prob_m1_0 + prob_1_0) / (prob_1_1 + prob_1_0 + prob_m1_0 + prob_m1_1)
+				prob_z_1 = (prob_m1_1 + prob_1_1) / (prob_1_1 + prob_1_0 + prob_m1_0 + prob_m1_1)
+
+				probc_m1_0 = prob_m1_0 / (prob_1_1 + prob_1_0 + prob_m1_0 + prob_m1_1)
+				probc_m1_1 = prob_m1_1 / (prob_1_1 + prob_1_0 + prob_m1_0 + prob_m1_1)
+
+				c_0 = prob_y_1 - 0.5
+				c_1 = u_1 * (probc_m1_0 - a*prob_z_0) + u_2 * (probc_m1_1 - a*prob_z_1)
+				c_2 = l_1 * (- probc_m1_0 + b*prob_z_0) + l_2 * (- probc_m1_1 + b*prob_z_1)
+
+				t = math.sqrt((c_0 + c_1 + c_2)*(c_0 + c_1 + c_2) + mu*mu)
+				t1 = (c_0 + c_1 + c_2) * (probc_m1_0 - a*prob_z_0)/t
+				t2 = (c_0 + c_1 + c_2) * (probc_m1_1 - a*prob_z_1)/t
+				t3 = (c_0 + c_1 + c_2) * (- probc_m1_0 + b*prob_z_0)/t
+				t4 = (c_0 + c_1 + c_2) * (- probc_m1_1 + b*prob_z_1)/t
+				#print(t1,t2)
+				res1.append(t1)
+				res2.append(t2)
+				res3.append(t3)
+				res4.append(t4)
+
+		return [np.mean(res1), np.mean(res2), np.mean(res3), np.mean(res4)]
+
+	def getValueForX(self, dist_params, a,b, params, samples,  z_0, z_1, x, flag):
+				u_1, u_2, l_1, l_2 = params[0], params[1], params[2], params[3]
+				#print (params)
+				a, b = a[0], b[0]
+
+				temp = np.append(np.append(x, 1), 1)
+				prob_1_1 = ut.getProbability(dist_params, temp)
+
+				temp = np.append(np.append(x, -1), 1)
+				prob_m1_1 = ut.getProbability(dist_params, temp)
+
+				temp = np.append(np.append(x, 1), 0)
+				prob_1_0 = ut.getProbability(dist_params, temp)
+
+				temp = np.append(np.append(x, -1), 0)
+				prob_m1_0 = ut.getProbability(dist_params, temp)
+				
+				if (prob_1_1 + prob_1_0 + prob_m1_0 + prob_m1_1) == 0:
+					print("Probability is 0.\n")
+					return 0
+
+				prob_y_1 = (prob_1_1 + prob_1_0) / (prob_1_1 + prob_1_0 + prob_m1_0 + prob_m1_1)
+				#print(prob_y_1)
+
+				prob_z_0 = (prob_m1_0 + prob_1_0) / (prob_1_1 + prob_1_0 + prob_m1_0 + prob_m1_1)
+				prob_z_1 = (prob_m1_1 + prob_1_1) / (prob_1_1 + prob_1_0 + prob_m1_0 + prob_m1_1)
+
+
+				probc_m1_0 = prob_m1_0 / (prob_1_1 + prob_1_0 + prob_m1_0 + prob_m1_1)
+				probc_m1_1 = prob_m1_1 / (prob_1_1 + prob_1_0 + prob_m1_0 + prob_m1_1)
+
+				c_0 = prob_y_1 - 0.5
+				c_1 = u_1 * (probc_m1_0 - a*prob_z_0) + u_2 * (probc_m1_1 - a*prob_z_1)
+				c_2 = l_1 * (- probc_m1_0 + b*prob_z_0) + l_2 * (- probc_m1_1 + b*prob_z_1)
+				if flag==1:
+					print(c_0, c_1, c_2, prob_1_1 + prob_1_0 + prob_m1_0 + prob_m1_1)
+
+				# c_1 = prob_z_0/z_0
+				# c_2 = prob_z_1/z_1
+
+				t = c_0 + c_1 + c_2
+				return t
+
+	def getFuncValue(self, dist_params, a,b, params, samples,  z_0, z_1):
+		res = []
+		for x in samples:
+				t = abs(self.getValueForX(dist_params, a,b, params, samples,  z_0, z_1, x, 0))
+				res.append(t)
+
+		exp = np.mean(res)
+		return exp
+
+	def getNumOfParams(self):
+		return 4
+
+	def getGamma(self, y_test, y_res, x_control_test):
+			pos_0 = 0
+			pos_1 = 0
+
+			z1_0 = 0
+			z1_1 = 0
+			for j in range(0,len(y_test)):
+				result = y_res[j]
+
+				if result == 1 and x_control_test[j] == 0:
+					z1_0 += 1
+				if result == 1 and x_control_test[j] == 1:
+					z1_1 += 1
+
+				actual = y_test[j]
+				if result == 1 and actual == -1 and x_control_test[j] == 0:
+					pos_0 += 1
+				if result == 1 and actual == -1 and x_control_test[j] == 1:
+					pos_1 += 1
+
+			pos_0 = float(pos_0)/z1_0
+			pos_1 = float(pos_1)/z1_1
+			if pos_0 == 0 or pos_1 == 0:
+				return 0
+			else:			
+				return min(pos_0/pos_1 , pos_1/pos_0)
+
+
+if __name__ == '__main__':
+	obj = FalseDiscovery()
+	obj.testPreprocessedData()
+	#obj.testSyntheticData()
+

--- a/aif360/algorithms/inprocessing/celisMeta/FalseDiscovery.py
+++ b/aif360/algorithms/inprocessing/celisMeta/FalseDiscovery.py
@@ -3,8 +3,12 @@ from scipy.stats import multivariate_normal
 import scipy.stats as st
 import numpy as np
 import math
-from General import *
-import utils as ut
+
+import site
+site.addsitedir('.')
+
+from .General import *
+from . import utils as ut
 
 
 class FalseDiscovery(General):

--- a/aif360/algorithms/inprocessing/celisMeta/General.py
+++ b/aif360/algorithms/inprocessing/celisMeta/General.py
@@ -88,7 +88,7 @@ class General:
 		span = self.getRange(eps, tau)
 		for (a,b) in span:
 			acc, gamma = 0, 0
-			print("-----",a,b)
+			#print("-----",a,b)
 			samples = ut.getRandomSamples(dist_params_train)
 
 			#try : 
@@ -105,15 +105,16 @@ class General:
 
 			acc = ut.getAccuracy(y_train, y_res)
 			gamma = self.getGamma(y_train, y_res, x_control_train)
-			print(acc, gamma)
+			#print(acc, gamma)
 
-			if maxAcc < acc and gamma >= tau - 0.1:
+			if maxAcc < acc and gamma >= tau - 0.2:
 				maxGamma = gamma
 				maxAcc = acc
 				p = a
 				q = b
 				paramsOpt = params
 
+		print("Training Accuracy: ", maxAcc, ", Training gamma: ", maxGamma)
 		def model(x):
 			return self.getValueForX(dist_params, p, q, paramsOpt, samples,  z_0, z_1, x, 0)
 

--- a/aif360/algorithms/inprocessing/celisMeta/General.py
+++ b/aif360/algorithms/inprocessing/celisMeta/General.py
@@ -1,0 +1,222 @@
+import os,sys
+from scipy.stats import multivariate_normal
+import scipy.stats as st
+import numpy as np
+import math
+from sklearn.mixture import GaussianMixture
+import logging
+import utils as ut
+
+# This is the class with the general functions of the algorithm. 
+# For different fairness metrics, the objective function of the optimization problem is different and hence needs different implementations.
+# The fairness-metric specific methods need to extend this class and implement the necessary functions
+class General:
+
+	# Used in gradient descent algorithm. Returns the value of gradient at any step.
+	def getExpectedGrad(self, dist_params, params, samples, mu,  z_0, z_1, a, b):
+		raise NotImplementedError("Expected gradient function not implemented")
+		return []
+
+	# Returns the threshold value at any point.
+	def getValueForX(self, dist_params, a,b, params, samples,  z_0, z_1, x, flag):
+		raise NotImplementedError("GetValueForX function not implemented")
+		return 0
+
+	# Returns the value of the objective function for given parameters.
+	def getFuncValue(self, dist_params, a,b, params, samples,  z_0, z_1):
+		raise NotImplementedError("Value function not implemented")
+		return 0
+
+	def getNumOfParams(self):
+		raise NotImplementedError("Specify number of params")
+		return 0
+
+	def getRange(self, eps, tau):
+		span = []
+		L = math.ceil(tau/eps)
+		for i in range(1, int(L+1), 10):
+			a = (i-1) * eps
+			b = (i) * eps / tau
+			if b > 1:
+				b = 1.0
+
+			span.append(([a, -1],[b, -1]))
+		return span
+
+	def getGamma(self, y_test, y_res, x_control_test):
+		raise NotImplementedError("Gamma function not implemented")
+		return 0
+
+	def getStartParams(self, i):
+		num = self.getNumOfParams()
+		return [i] * num
+
+	# Gradient Descent implementation for the optimizing the objective function.
+	# Note that one can alternately also use packages like CVXPY here.
+	# Here we use decaying step size. For certain objectives, constant step size might be better.
+	def gradientDescent(self, dist_params, a, b, samples, z_0, z_1):
+		mu = 0.01
+		minVal = 100000000
+		size = self.getNumOfParams()
+
+		minParam = [0] * size
+
+		for i in range(1,10):
+			params = self.getStartParams(i)
+			for k in range(1,50):
+				grad = self.getExpectedGrad(dist_params, params, samples, mu, z_0, z_1, a, b)
+				for j in range(0, len(params)):
+					params[j] = params[j] - 0.05/k * grad[j]
+				funcVal = self.getFuncValue(dist_params, a,b, params, samples, z_0, z_1)
+				if funcVal < minVal:
+					minVal, minParam = funcVal, params
+
+		return minParam
+
+	# Returns the model given the training data and input tau.
+	def getModel(self, tau, x_train, y_train, x_control_train):
+		dist_params, dist_params_train =  ut.getDistribution(x_train, y_train, x_control_train)
+		eps = 0.01
+		L = math.ceil(tau/eps)
+		z_1 = sum(x_control_train)/(float(len(x_control_train)))
+		z_0 = 1 - z_1
+		p, q  = [0,0],[0,0]
+		paramsOpt, samples = [], []
+		maxAcc = 0
+		maxGamma = 0
+
+		span = self.getRange(eps, tau)
+		for (a,b) in span:
+			acc, gamma = 0, 0
+			print("-----",a,b)
+			samples = ut.getRandomSamples(dist_params_train)
+
+			#try : 
+			params = self.gradientDescent(dist_params, a, b, samples, z_0, z_1)
+			#print(params)
+			y_res = []
+
+			for x in x_train:
+				t = self.getValueForX(dist_params, a,b, params, samples,  z_0, z_1, x, 0)
+				if t > 0 :
+					y_res.append(1)
+				else:
+					y_res.append(-1)
+
+			acc = ut.getAccuracy(y_train, y_res)
+			gamma = self.getGamma(y_train, y_res, x_control_train)
+			print(acc, gamma)
+
+			if maxAcc < acc and gamma >= tau - 0.1:
+				maxGamma = gamma
+				maxAcc = acc
+				p = a
+				q = b
+				paramsOpt = params
+
+		def model(x):
+			return self.getValueForX(dist_params, p, q, paramsOpt, samples,  z_0, z_1, x, 0)
+
+		return model
+
+	def processGivenData(self, tau, x_train, y_train, x_control_train, x_test, y_test, x_control_test, dist_params, dist_params_train):
+		model = self.getModel(tau, x_train, y_train, x_control_train)
+
+		y_test_res = []
+		for x in x_test:
+				#t = self.getValueForX(dist_params, p, q, paramsOpt, samples,  z_0, z_1, x, 0)
+				t = model(x)
+				if t > 0 :
+					y_test_res.append(1)
+				else:
+					y_test_res.append(-1)
+		#f.write(str(tau) + " " + str(self.getGamma(y_test, y_test_res, x_control_test)) + " " + str(ut.getAccuracy(y_test, y_test_res)) + "\n")
+		return y_test_res
+
+	def test_given_data(self, x_train, y_train, x_control_train, x_test, y_test, x_control_test, sensitive_attrs, tau):
+		attr = sensitive_attrs[0]
+		x_control_train = x_control_train[attr]
+		x_control_test = x_control_test[attr]
+
+		l = len(y_train)
+
+
+		#print(mean, cov)
+
+		return self.processGivenData(tau, x_train, y_train, x_control_train, x_test, y_test, x_control_test, [], [])
+
+	global getData
+
+	def testPreprocessedData(self):
+		x_train, y_train, x_control_train, x_control_test, x_test, y_test = ut.getData()
+		#checkNormalFit(x_train, y_train, x_control_train)
+
+		for i in range(1,11):
+			try : 
+				tau = i/10.0
+				print("Tau : ", tau)
+				y_res = self.processGivenData(tau, x_train, y_train, x_control_train, x_test, y_test, x_control_test, [], [])
+				ut.getStats(y_test, y_res, x_control_test)
+				print("\n")
+			except Exception as e:
+				logging.exception(str(tau) + " failed\n" + str(e))
+
+	def testSyntheticData(self):
+		#A,S,F = [],[],[]
+		x_train, y_train, x_control_train, x_control_test, x_test, y_test = ut.getData()
+		dist_params, dist_params_train =  ut.getDistribution(x_train, y_train, x_control_train)
+
+		mean, cov, meanT, covT = dist_params["mean"], dist_params["cov"], dist_params_train["mean"], dist_params_train["cov"]
+		#print(mean)
+		meanN = [0] * len(mean)
+		covN = np.identity(len(mean))
+
+		#clf = GaussianMixture(n_components=2, covariance_type='full')
+		means = [mean, meanN]
+		covariances = [cov, covN]
+		lw = float(sys.argv[2])
+		weights = [1-lw, lw]
+
+		#for i in range(0,4):
+		LR, LE = len(y_train), len(y_test)
+		train, test = [],[]
+		for i in range(0, LR):
+			j = np.random.choice([0,1], p=weights)
+			seed = np.random.randint(10)
+			train.append(multivariate_normal(means[j], covariances[j], allow_singular=1).rvs(size=1, random_state=seed))
+		for i in range(0, LE):
+			j = np.random.choice([0,1], p=weights)
+			seed = np.random.randint(10)
+			test.append(multivariate_normal(means[j], covariances[j], allow_singular=1).rvs(size=1, random_state=seed))
+
+		x_train, y_train, x_control_train = [], [], []
+		for t in train:
+			x_train.append(t[:-2])
+			if t[len(t)-2] < 0:
+				y_train.append(-1)
+			else:
+				y_train.append(1)
+			#y_train.append(t[len(t)-2])
+			if t[len(t)-1] < 0.5:
+				x_control_train.append(0)
+			else:
+				x_control_train.append(1)
+
+		x_control_test, x_test, y_test = [], [], []
+		for t in test:
+			x_test.append(t[:-2])
+			if t[len(t)-2] < 0:
+				y_test.append(-1)
+			else:
+				y_test.append(1)
+			if t[len(t)-1] < 0.5:
+				x_control_test.append(0)
+			else:
+				x_control_test.append(1)
+
+		#print(x_train, y_train, x_control_train)
+		y_res = self.processGivenData(0.9, x_train, y_train, x_control_train, x_test, y_test, x_control_test, dist_params, dist_params_train)
+		acc, sr, fdr = ut.getStats(y_test, y_res, x_control_test)
+		print("Acc: ", acc, " SR: ", sr, " FDR: ", fdr)
+
+		#print("\n", np.mean(A), np.std(A), np.mean(S), np.std(S), np.mean(F), np.std(F))

--- a/aif360/algorithms/inprocessing/celisMeta/General.py
+++ b/aif360/algorithms/inprocessing/celisMeta/General.py
@@ -66,7 +66,7 @@ class General:
 			for k in range(1,50):
 				grad = self.getExpectedGrad(dist_params, params, samples, mu, z_0, z_1, a, b)
 				for j in range(0, len(params)):
-					params[j] = params[j] - 0.05/k * grad[j]
+					params[j] = params[j] - 1/k * grad[j]
 				funcVal = self.getFuncValue(dist_params, a,b, params, samples, z_0, z_1)
 				if funcVal < minVal:
 					minVal, minParam = funcVal, params
@@ -75,6 +75,9 @@ class General:
 
 	# Returns the model given the training data and input tau.
 	def getModel(self, tau, x_train, y_train, x_control_train):
+		if tau == 0:
+			return self.getUnbiasedModel(x_train, y_train, x_control_train)
+
 		dist_params, dist_params_train =  ut.getDistribution(x_train, y_train, x_control_train)
 		eps = 0.01
 		L = math.ceil(tau/eps)
@@ -117,6 +120,20 @@ class General:
 		print("Training Accuracy: ", maxAcc, ", Training gamma: ", maxGamma)
 		def model(x):
 			return self.getValueForX(dist_params, p, q, paramsOpt, samples,  z_0, z_1, x, 0)
+
+		return model
+
+	def getUnbiasedModel(self, x_train, y_train, x_control_train):
+		dist_params, dist_params_train =  ut.getDistribution(x_train, y_train, x_control_train)
+		eps = 0.01
+		z_1 = sum(x_control_train)/(float(len(x_control_train)))
+		z_0 = 1 - z_1
+		p, q  = [0,0],[0,0]
+		params = [0]*self.getNumOfParams()
+		samples = ut.getRandomSamples(dist_params_train)
+
+		def model(x):
+			return self.getValueForX(dist_params, p, q, params, samples,  z_0, z_1, x, 0)
 
 		return model
 

--- a/aif360/algorithms/inprocessing/celisMeta/General.py
+++ b/aif360/algorithms/inprocessing/celisMeta/General.py
@@ -5,7 +5,7 @@ import numpy as np
 import math
 from sklearn.mixture import GaussianMixture
 import logging
-import utils as ut
+from . import utils as ut
 
 # This is the class with the general functions of the algorithm. 
 # For different fairness metrics, the objective function of the optimization problem is different and hence needs different implementations.

--- a/aif360/algorithms/inprocessing/celisMeta/StatisticalRate.py
+++ b/aif360/algorithms/inprocessing/celisMeta/StatisticalRate.py
@@ -1,0 +1,147 @@
+import os,sys
+from scipy.stats import multivariate_normal
+import scipy.stats as st
+import numpy as np
+import math
+from General import *
+import utils as ut
+
+
+class StatisticalRate(General):
+
+	def getExpectedGrad(self, dist_params, params, samples, mu,  z_0, z_1, a, b):
+		a, b = a[0], b[0]
+		l_1, l_2 = params[0], params[1]
+		res1 = []
+		res2 = []
+		for x in samples:
+			temp = np.append(np.append(x, 1), 1)
+			prob_1_1 = ut.getProbability(dist_params, temp)
+
+			temp = np.append(np.append(x, -1), 1)
+			prob_m1_1 = ut.getProbability(dist_params, temp)
+
+			temp = np.append(np.append(x, 1), 0)
+			prob_1_0 = ut.getProbability(dist_params, temp)
+
+			temp = np.append(np.append(x, -1), 0)
+			prob_m1_0 = ut.getProbability(dist_params, temp)
+
+
+			prob_y_1 = (prob_1_1 + prob_1_0) / (prob_1_1 + prob_1_0 + prob_m1_0 + prob_m1_1)
+			#print(prob_y_1)
+
+			prob_z_0 = (prob_m1_0 + prob_1_0) / (prob_1_1 + prob_1_0 + prob_m1_0 + prob_m1_1)
+			prob_z_1 = (prob_m1_1 + prob_1_1) / (prob_1_1 + prob_1_0 + prob_m1_0 + prob_m1_1)
+
+			c_0 = prob_y_1 - 0.5
+			c_1 = prob_z_0/z_0
+			c_2 = prob_z_1/z_1
+
+			t = math.sqrt((c_0 + c_1*l_1 + c_2*l_2)*(c_0 + c_1*l_1 + c_2*l_2) + mu*mu)
+			t1 = (c_0 + c_1*l_1 + c_2*l_2) * c_1/t
+			t2 = (c_0 + c_1*l_1 + c_2*l_2) * c_2/t
+			#print(t1,t2)
+			res1.append(t1)
+			res2.append(t2)
+
+		exp1 = np.mean(res1)
+		exp2 = np.mean(res2)
+		dl1 = exp1 - b + (b-a)/2 + (b-a)* l_1 / (2* math.sqrt(l_1*l_1 + mu*mu)) 
+		dl2 = exp2 - b + (b-a)/2 + (b-a)* l_2 / (2* math.sqrt(l_2*l_2 + mu*mu)) 
+		return [dl1, dl2]
+
+	def getValueForX(self, dist_params, a,b, params, samples,  z_0, z_1, x, flag):
+			a, b = a[0], b[0]
+			l_1, l_2 = params[0], params[1]
+
+			temp = np.append(np.append(x, 1), 1)
+			prob_1_1 = ut.getProbability(dist_params, temp)
+
+			temp = np.append(np.append(x, -1), 1)
+			prob_m1_1 = ut.getProbability(dist_params, temp)
+
+			temp = np.append(np.append(x, 1), 0)
+			prob_1_0 = ut.getProbability(dist_params, temp)
+
+			temp = np.append(np.append(x, -1), 0)
+			prob_m1_0 = ut.getProbability(dist_params, temp)
+			if (prob_1_1 + prob_1_0 + prob_m1_0 + prob_m1_1) == 0:
+				#print("Probability is 0.\n")
+				return 0
+
+
+			prob_y_1 = (prob_1_1 + prob_1_0) / (prob_1_1 + prob_1_0 + prob_m1_0 + prob_m1_1)
+			#print(prob_y_1)
+
+			prob_z_0 = (prob_m1_0 + prob_1_0) / (prob_1_1 + prob_1_0 + prob_m1_0 + prob_m1_1)
+			prob_z_1 = (prob_m1_1 + prob_1_1) / (prob_1_1 + prob_1_0 + prob_m1_0 + prob_m1_1)
+
+			c_0 = prob_y_1 - 0.5
+			c_1 = prob_z_0/z_0
+			c_2 = prob_z_1/z_1
+			if flag==1:
+				print(c_0, c_1, c_2, prob_1_1 + prob_1_0 + prob_m1_0 + prob_m1_1)
+
+			t = c_0 + c_1*l_1 + c_2*l_2
+			return t
+
+	def getFuncValue(self, dist_params, a,b, params, samples,  z_0, z_1):
+		res = []
+		for x in samples:
+				t = abs(self.getValueForX(dist_params, a,b, params, samples,  z_0, z_1, x, 0))
+				res.append(t)
+
+		l_1 = params[0]
+		l_2 = params[1]
+		a, b = a[0], b[0]
+
+		exp = np.mean(res)
+		result = exp - b*l_1 - b*l_2
+		if l_1 > 0 :
+			result += (b-a)*l_1
+		if l_2 > 0 :
+			result += (b-a)*l_2
+
+		return result
+
+	def getNumOfParams(self):
+		return 2
+
+	def getStartParams(self, i):
+		num = self.getNumOfParams()
+		return [i-5] * num
+
+	def getGamma(self, y_test, y_res, x_control_test):
+			pos_0 = 0
+			pos_1 = 0
+
+			z1_0 = 0
+			z1_1 = 0
+			for j in range(0,len(y_test)):
+				result = y_res[j]
+				actual = y_test[j]
+
+				if x_control_test[j] == 0:
+					z1_0 += 1
+				if x_control_test[j] == 1:
+					z1_1 += 1
+
+				if result == 1 and x_control_test[j] == 0:
+					pos_0 += 1
+				if result == 1 and x_control_test[j] == 1:
+					pos_1 += 1
+
+
+			pos_0 = float(pos_0)/z1_0
+			pos_1 = float(pos_1)/z1_1
+			if pos_0 == 0 or pos_1 == 0:
+				return 0
+			else:			
+				return min(pos_0/pos_1 , pos_1/pos_0)
+
+
+if __name__ == '__main__':
+	obj = StatisticalRate()
+	obj.testPreprocessedData()
+	#obj.testSyntheticData()

--- a/aif360/algorithms/inprocessing/celisMeta/StatisticalRate.py
+++ b/aif360/algorithms/inprocessing/celisMeta/StatisticalRate.py
@@ -3,8 +3,12 @@ from scipy.stats import multivariate_normal
 import scipy.stats as st
 import numpy as np
 import math
-from General import *
-import utils as ut
+
+import site
+site.addsitedir('.')
+
+from .General import *
+from . import utils as ut
 
 
 class StatisticalRate(General):

--- a/aif360/algorithms/inprocessing/celisMeta/__init__.py
+++ b/aif360/algorithms/inprocessing/celisMeta/__init__.py
@@ -1,0 +1,3 @@
+from aif360.algorithms.inprocessing.celisMeta.FalseDiscovery import FalseDiscovery
+from aif360.algorithms.inprocessing.celisMeta.StatisticalRate import StatisticalRate
+import aif360.algorithms.inprocessing.celisMeta.utils

--- a/aif360/algorithms/inprocessing/celisMeta/utils.py
+++ b/aif360/algorithms/inprocessing/celisMeta/utils.py
@@ -73,7 +73,7 @@ def getStats(y_test, y_res, x_control_test):
 		total_0 = float(total_0)
 		total_1 = float(total_1)
 
-		print("Accuracy DIFF: ", abs(pos_0/total_0 - pos_1/total_1)) 
+		#print("Accuracy DIFF: ", abs(pos_0/total_0 - pos_1/total_1)) 
 
 		pos_0 = 0
 		pos_1 = 0
@@ -97,40 +97,13 @@ def getStats(y_test, y_res, x_control_test):
 
 		pos_0 = float(pos_0)/z1_0
 		pos_1 = float(pos_1)/z1_1
-		if pos_0 == 0 or pos_1 == 0:
-				print("Observed tau : 0")
-		else:			
-			print("TPR DIFF : ", abs(pos_0 - pos_1))
+		# if pos_0 == 0 or pos_1 == 0:
+		# 		print("Observed tau : 0")
+		# else:			
+		# 	print("TPR DIFF : ", abs(pos_0 - pos_1))
 
 
 
-		pos_0 = 0
-		pos_1 = 0
-
-		z1_0 = 0
-		z1_1 = 0
-		for j in range(0,len(y_test)):
-			result = y_res[j]
-
-			if result == 1 and x_control_test[j] == 0:
-				z1_0 += 1
-			if result == 1 and x_control_test[j] == 1:
-				z1_1 += 1
-
-			actual = y_test[j]
-			if result == 1 and actual == -1 and x_control_test[j] == 0:
-				pos_0 += 1
-			if result == 1 and actual == -1 and x_control_test[j] == 1:
-				pos_1 += 1
-
-
-		pos_0 = float(pos_0)/z1_0
-		pos_1 = float(pos_1)/z1_1
-		if pos_0 == 0 or pos_1 == 0:
-				print("Observed tau : 0")
-		else:			
-			print("FDR tau : ", min(pos_0/pos_1 , pos_1/pos_0))
-		fdr = min(pos_0/pos_1 , pos_1/pos_0)
 
 		total = 0
 		fail = 0
@@ -315,6 +288,33 @@ def getStats(y_test, y_res, x_control_test):
 		else:			
 			print("AR tau : ", min(pos_0/pos_1 , pos_1/pos_0))
 
+		pos_0 = 0
+		pos_1 = 0
+
+		z1_0 = 0
+		z1_1 = 0
+		for j in range(0,len(y_test)):
+			result = y_res[j]
+
+			if result == 1 and x_control_test[j] == 0:
+				z1_0 += 1
+			if result == 1 and x_control_test[j] == 1:
+				z1_1 += 1
+
+			actual = y_test[j]
+			if result == 1 and actual == -1 and x_control_test[j] == 0:
+				pos_0 += 1
+			if result == 1 and actual == -1 and x_control_test[j] == 1:
+				pos_1 += 1
+
+
+		pos_0 = float(pos_0)/z1_0
+		pos_1 = float(pos_1)/z1_1
+		if pos_0 == 0 or pos_1 == 0:
+				print("Observed tau : 0")
+		else:			
+			print("FDR tau : ", min(pos_0/pos_1 , pos_1/pos_0))
+		fdr = min(pos_0/pos_1 , pos_1/pos_0)
 
 		pos_0 = 0
 		pos_1 = 0

--- a/aif360/algorithms/inprocessing/celisMeta/utils.py
+++ b/aif360/algorithms/inprocessing/celisMeta/utils.py
@@ -1,0 +1,487 @@
+import os,sys
+from scipy.stats import multivariate_normal
+import scipy.stats as st
+import numpy as np
+import math
+from sklearn.mixture import GaussianMixture
+import logging
+
+def getDistribution(x_train, y_train, x_control_train):
+	train = list(x_train)
+	for i in range(0,len(train)):
+		train[i] = np.append(train[i], y_train[i])
+		train[i] = np.append(train[i], x_control_train[i])
+
+	#print(train)
+
+	mean = np.mean(train, axis=0)
+	cov = np.cov(train, rowvar=0)
+	clf = GaussianMixture(n_components=2, covariance_type='full')
+	model = clf.fit(train)
+
+	dist_params = {"mean":mean, "cov":cov, "model":model}
+
+	mean_train = np.mean(x_train, axis=0)
+	cov_train = np.cov(x_train, rowvar=0)
+	clf_train = GaussianMixture(n_components=2, covariance_type='full')
+	model_train = clf_train.fit(list(x_train))
+
+	#print(train, train_label, train_label==train)
+
+	dist_params_train = {"mean":mean_train, "cov":cov_train, "model":model_train}
+	return dist_params, dist_params_train
+
+def getProbability(dist_params, x):
+	mean, cov = dist_params["mean"], dist_params["cov"]
+	return multivariate_normal.pdf(x, mean=mean, cov=cov, allow_singular=1)
+
+def getRandomSamples(dist_params_train):
+	mean, cov, model = dist_params_train["mean"], dist_params_train["cov"], dist_params_train["model"]
+	return multivariate_normal(mean, cov, allow_singular=1).rvs(size=20, random_state=12345)
+
+def getAccuracy(y_test, y_res):
+	total, fail = 0, 0
+	for j in range(0,len(y_test)):
+		result = y_res[j]
+		actual = y_test[j]
+		total += 1
+		if actual != result:
+			fail += 1
+
+	return 1 - fail/(float(total))
+
+def getStats(y_test, y_res, x_control_test):
+	try:
+		total_0 = 0
+		total_1 = 0
+		fail = 0
+		pos_0 = 0
+		pos_1 = 0
+		for j in range(0,len(y_test)):
+			result = y_res[j]
+			actual = y_test[j]
+
+			if x_control_test[j] == 0:
+				total_0 += 1
+				if actual == result:
+					pos_0 += 1
+			else:
+				total_1 += 1
+				if actual == result:
+					pos_1 += 1
+
+		total_0 = float(total_0)
+		total_1 = float(total_1)
+
+		print("Accuracy DIFF: ", abs(pos_0/total_0 - pos_1/total_1)) 
+
+		pos_0 = 0
+		pos_1 = 0
+
+		z1_0 = 0
+		z1_1 = 0
+		for j in range(0,len(y_test)):
+			result = y_res[j]
+			actual = y_test[j]
+
+			if actual == 1 and x_control_test[j] == 0:
+				z1_0 += 1
+			if actual == 1 and x_control_test[j] == 1:
+				z1_1 += 1
+
+			if result == 1 and actual == 1 and x_control_test[j] == 0:
+				pos_0 += 1
+			if result == 1 and actual == 1 and x_control_test[j] == 1:
+				pos_1 += 1
+
+
+		pos_0 = float(pos_0)/z1_0
+		pos_1 = float(pos_1)/z1_1
+		if pos_0 == 0 or pos_1 == 0:
+				print("Observed tau : 0")
+		else:			
+			print("TPR DIFF : ", abs(pos_0 - pos_1))
+
+
+
+		pos_0 = 0
+		pos_1 = 0
+
+		z1_0 = 0
+		z1_1 = 0
+		for j in range(0,len(y_test)):
+			result = y_res[j]
+
+			if result == 1 and x_control_test[j] == 0:
+				z1_0 += 1
+			if result == 1 and x_control_test[j] == 1:
+				z1_1 += 1
+
+			actual = y_test[j]
+			if result == 1 and actual == -1 and x_control_test[j] == 0:
+				pos_0 += 1
+			if result == 1 and actual == -1 and x_control_test[j] == 1:
+				pos_1 += 1
+
+
+		pos_0 = float(pos_0)/z1_0
+		pos_1 = float(pos_1)/z1_1
+		if pos_0 == 0 or pos_1 == 0:
+				print("Observed tau : 0")
+		else:			
+			print("FDR tau : ", min(pos_0/pos_1 , pos_1/pos_0))
+		fdr = min(pos_0/pos_1 , pos_1/pos_0)
+
+		total = 0
+		fail = 0
+		pos_0 = 0
+		pos_1 = 0
+		for j in range(0,len(y_test)):
+			result = y_res[j]
+			actual = y_test[j]
+
+			total += 1
+			if actual != result:
+				fail += 1
+
+
+		print("Accuracy : ", fail, total, 1 - fail/(float(total))) 
+		acc = 1 - fail/(float(total))
+
+		pos_0 = 0
+		pos_1 = 0
+
+		z1_0 = 0
+		z1_1 = 0
+		for j in range(0,len(y_test)):
+			result = y_res[j]
+			actual = y_test[j]
+
+			if x_control_test[j] == 0:
+				z1_0 += 1
+			if x_control_test[j] == 1:
+				z1_1 += 1
+
+			if result == 1 and x_control_test[j] == 0:
+				pos_0 += 1
+			if result == 1 and x_control_test[j] == 1:
+				pos_1 += 1
+
+
+		pos_0 = float(pos_0)/z1_0
+		pos_1 = float(pos_1)/z1_1
+		if pos_0 == 0 or pos_1 == 0:
+				print("Observed tau : 0")
+		else:			
+			print("SR tau : ", min(pos_0/pos_1 , pos_1/pos_0))
+		sr = min(pos_0/pos_1 , pos_1/pos_0)
+
+
+		pos_0 = 0
+		pos_1 = 0
+
+		z1_0 = 0
+		z1_1 = 0
+		for j in range(0,len(y_test)):
+			result = y_res[j]
+			actual = y_test[j]
+
+			if actual == -1 and x_control_test[j] == 0:
+				z1_0 += 1
+			if actual == -1 and x_control_test[j] == 1:
+				z1_1 += 1
+
+			if result == 1 and actual == -1 and x_control_test[j] == 0:
+				pos_0 += 1
+			if result == 1 and actual == -1 and x_control_test[j] == 1:
+				pos_1 += 1
+
+
+		pos_0 = float(pos_0)/z1_0
+		pos_1 = float(pos_1)/z1_1
+		if pos_0 == 0 or pos_1 == 0:
+				print("Observed tau : 0")
+		else:			
+			print("FPR tau : ", min(pos_0/pos_1 , pos_1/pos_0))
+
+
+		pos_0 = 0
+		pos_1 = 0
+
+		z1_0 = 0
+		z1_1 = 0
+		for j in range(0,len(y_test)):
+			result = y_res[j]
+			actual = y_test[j]
+
+			if actual == 1 and x_control_test[j] == 0:
+				z1_0 += 1
+			if actual == 1 and x_control_test[j] == 1:
+				z1_1 += 1
+
+			if result == -1 and actual == 1 and x_control_test[j] == 0:
+				pos_0 += 1
+			if result == -1 and actual == 1 and x_control_test[j] == 1:
+				pos_1 += 1
+
+
+		pos_0 = float(pos_0)/z1_0
+		pos_1 = float(pos_1)/z1_1
+		if pos_0 == 0 or pos_1 == 0:
+				print("Observed tau : 0")
+		else:			
+			print("FNR tau : ", min(pos_0/pos_1 , pos_1/pos_0))
+
+		pos_0 = 0
+		pos_1 = 0
+
+		z1_0 = 0
+		z1_1 = 0
+		for j in range(0,len(y_test)):
+			result = y_res[j]
+			actual = y_test[j]
+
+			if actual == 1 and x_control_test[j] == 0:
+				z1_0 += 1
+			if actual == 1 and x_control_test[j] == 1:
+				z1_1 += 1
+
+			if result == 1 and actual == 1 and x_control_test[j] == 0:
+				pos_0 += 1
+			if result == 1 and actual == 1 and x_control_test[j] == 1:
+				pos_1 += 1
+
+
+		pos_0 = float(pos_0)/z1_0
+		pos_1 = float(pos_1)/z1_1
+		if pos_0 == 0 or pos_1 == 0:
+				print("Observed tau : 0")
+		else:			
+			print("TPR tau : ", min(pos_0/pos_1 , pos_1/pos_0))
+
+
+		pos_0 = 0
+		pos_1 = 0
+
+		z1_0 = 0
+		z1_1 = 0
+		for j in range(0,len(y_test)):
+			result = y_res[j]
+			actual = y_test[j]
+
+			if actual == -1 and x_control_test[j] == 0:
+				z1_0 += 1
+			if actual == -1 and x_control_test[j] == 1:
+				z1_1 += 1
+
+			if result == -1 and actual == -1 and x_control_test[j] == 0:
+				pos_0 += 1
+			if result == -1 and actual == -1 and x_control_test[j] == 1:
+				pos_1 += 1
+
+
+		pos_0 = float(pos_0)/z1_0
+		pos_1 = float(pos_1)/z1_1
+		if pos_0 == 0 or pos_1 == 0:
+				print("Observed tau : 0")
+		else:			
+			print("TNR tau : ", min(pos_0/pos_1 , pos_1/pos_0))
+
+
+		pos_0 = 0
+		pos_1 = 0
+
+		z1_0 = 0
+		z1_1 = 0
+		for j in range(0,len(y_test)):
+			result = y_res[j]
+			actual = y_test[j]
+
+			if x_control_test[j] == 0:
+				z1_0 += 1
+			if x_control_test[j] == 1:
+				z1_1 += 1
+
+			if result == actual and x_control_test[j] == 0:
+				pos_0 += 1
+			if result == actual and x_control_test[j] == 1:
+				pos_1 += 1
+
+
+		pos_0 = float(pos_0)/z1_0
+		pos_1 = float(pos_1)/z1_1
+		if pos_0 == 0 or pos_1 == 0:
+				print("Observed tau : 0")
+		else:			
+			print("AR tau : ", min(pos_0/pos_1 , pos_1/pos_0))
+
+
+		pos_0 = 0
+		pos_1 = 0
+
+		z1_0 = 0
+		z1_1 = 0
+		for j in range(0,len(y_test)):
+			result = y_res[j]
+
+			if result == -1 and x_control_test[j] == 0:
+				z1_0 += 1
+			if result == -1 and x_control_test[j] == 1:
+				z1_1 += 1
+
+			actual = y_test[j]
+			if result == -1 and actual == 1 and x_control_test[j] == 0:
+				pos_0 += 1
+			if result == -1 and actual == 1 and x_control_test[j] == 1:
+				pos_1 += 1
+
+
+		pos_0 = float(pos_0)/z1_0
+		pos_1 = float(pos_1)/z1_1
+		if pos_0 == 0 or pos_1 == 0:
+				print("Observed tau : 0")
+		else:			
+			print("FOR tau : ", min(pos_0/pos_1 , pos_1/pos_0))
+
+		pos_0 = 0
+		pos_1 = 0
+
+		z1_0 = 0
+		z1_1 = 0
+		for j in range(0,len(y_test)):
+			result = y_res[j]
+
+			if result == 1 and x_control_test[j] == 0:
+				z1_0 += 1
+			if result == 1 and x_control_test[j] == 1:
+				z1_1 += 1
+
+			actual = y_test[j]
+			if result == 1 and actual == 1 and x_control_test[j] == 0:
+				pos_0 += 1
+			if result == 1 and actual == 1 and x_control_test[j] == 1:
+				pos_1 += 1
+
+
+		pos_0 = float(pos_0)/z1_0
+		pos_1 = float(pos_1)/z1_1
+		if pos_0 == 0 or pos_1 == 0:
+				print("Observed tau : 0")
+		else:			
+			print("PPR tau : ", min(pos_0/pos_1 , pos_1/pos_0))
+
+		pos_0 = 0
+		pos_1 = 0
+
+		z1_0 = 0
+		z1_1 = 0
+		for j in range(0,len(y_test)):
+			result = y_res[j]
+
+			if result == -1 and x_control_test[j] == 0:
+				z1_0 += 1
+			if result == -1 and x_control_test[j] == 1:
+				z1_1 += 1
+
+			actual = y_test[j]
+			if result == -1 and actual == -1 and x_control_test[j] == 0:
+				pos_0 += 1
+			if result == -1 and actual == -1 and x_control_test[j] == 1:
+				pos_1 += 1
+
+
+		pos_0 = float(pos_0)/z1_0
+		pos_1 = float(pos_1)/z1_1
+		if pos_0 == 0 or pos_1 == 0:
+				print("Observed tau : 0")
+		else:			
+			print("NPR tau : ", min(pos_0/pos_1 , pos_1/pos_0))
+
+		return acc, sr, fdr
+	except ZeroDivisionError:
+		print("Stats inconclusive")
+
+def getData():
+	x_control_train = []
+	x_train = []
+	y_train = []
+	x_control_test = []
+	x_test = []
+	y_test = []
+
+	folder = sys.argv[1]
+	temp = []
+	with open(folder + "/x_train.txt") as f:
+		temp = f.readlines()
+
+	for line in temp:
+		temp2 = line[:-1].split(' ')
+		a = []
+		for i in temp2[:-1]:
+			a.append(float(i))
+		x_train.append(np.array(a))
+	temp = []
+	with open(folder + "/x_test.txt") as f:
+		temp = f.readlines()
+
+	for line in temp:
+		temp2 = line.split(' ')
+		a = []
+		for i in temp2[:-1]:
+			a.append(float(i))
+		x_test.append(np.array(a))
+
+	temp = []
+	with open(folder + "/y_train.txt") as f:
+		temp = f.readlines()
+	for line in temp:
+		y_train.append(float(line))
+	y_train = np.array(y_train)
+
+	temp = []
+	with open(folder + "/y_test.txt") as f:
+		temp = f.readlines()
+	for line in temp:
+		y_test.append(float(line))
+	y_test = np.array(y_test)
+
+	temp = []
+	with open(folder + "/x_control_train.txt") as f:
+		temp = f.readlines()
+	for line in temp:
+		x_control_train.append(float(line))
+	x_control_train = np.array(x_control_train)
+
+	temp = []
+	with open(folder + "/x_control_test.txt") as f:
+		temp = f.readlines()
+	for line in temp:
+		x_control_test.append(float(line))
+	x_control_test = np.array(x_control_test)
+
+	return x_train, y_train, x_control_train, x_control_test, x_test, y_test
+
+def checkNormalFit(x_train, y_train, x_control_train):
+	train = []
+	for i in range(0, len(y_train)):
+		temp1 = np.append(x_train[i], y_train[i])
+		temp2 = np.append(temp1, x_control_train[i])
+		train.append(temp2)
+
+	mean = np.mean(train, axis=0)
+	cov = np.cov(train, rowvar=0)
+	l = len(mean) - 2
+	for i in range(0, l):
+		for j in range(0, l):
+			if i != j:				
+				cov[i][j] = 0
+
+	for i in range(0, len(train[0])):
+		data = []
+		for elem in train:
+			data.append(elem[i])
+
+		def cdf(x):
+			return st.norm.cdf(x, mean[i], math.sqrt(cov[i][i]))
+
+		print(st.kstest(data, cdf))

--- a/aif360/algorithms/inprocessing/meta_fair_classifier.py
+++ b/aif360/algorithms/inprocessing/meta_fair_classifier.py
@@ -98,15 +98,19 @@ class MetaFairClassifer(Transformer):
         all_sensitive_attributes = dataset.protected_attribute_names
  
         model = self.model_name
-        predictions, scores = [], []
+        predictions, y_res, scores = [], [], []
         for x in x_test:
             t = model(x)
             if t > 0 :
                 predictions.append(1)
+                y_res.append(1)
             else:
                 predictions.append(0)
+                y_res.append(-1)
             scores.append((t+1)/2)
 
+
+        #print("Gamma: ", self.obj.getGamma(y_test, y_res, x_control_test))
         pred_dataset = dataset.copy()
         pred_dataset.labels = np.array(predictions)
         pred_dataset.scores = np.array(scores)

--- a/aif360/algorithms/inprocessing/meta_fair_classifier.py
+++ b/aif360/algorithms/inprocessing/meta_fair_classifier.py
@@ -1,0 +1,122 @@
+# The code for Meta-Classification-Algorithm is based on, the paper https://arxiv.org/abs/1806.06055
+# See: https://github.com/vijaykeswani/FairClassification
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import numpy as np
+import pandas as pd
+import tempfile
+import os
+import subprocess
+
+from aif360.algorithms import Transformer
+from aif360.algorithms.inprocessing.celisMeta.FalseDiscovery import FalseDiscovery
+from aif360.algorithms.inprocessing.celisMeta.StatisticalRate import StatisticalRate
+
+class MetaFairClassifer(Transformer):
+    """The meta algorithm here takes the fairness metric as part of the input
+        and returns a classifier optimized w.r.t. that fairness metric.
+
+    References:
+        Celis, L. E., Huang, L., Keswani, V., & Vishnoi, N. K. (2018). 
+        "Classification with Fairness Constraints: A Meta-Algorithm with Provable Guarantees.""
+
+    """
+
+    def __init__(self, tau=0.8, sensitive_attr="", class_attr=""):
+        """
+        Args:
+            tau (double, optional): fairness penalty parameter
+            sensitive_attr (str, optional): name of protected attribute
+            class_attr (str, optional): label name
+        """
+        super(MetaFairClassifer, self).__init__(tau=tau,
+            sensitive_attr=sensitive_attr, class_attr=class_attr)
+        self.tau = tau
+        self.sensitive_attr = sensitive_attr
+        self.class_attr = class_attr
+
+    def fit(self, dataset):
+        """Learns the fair classifier.
+
+        Args:
+            dataset (BinaryLabelDataset): Dataset containing true labels.
+
+        Returns:
+            PrejudiceRemover: Returns self.
+        """        
+
+        data = np.column_stack([dataset.features, dataset.labels])
+        columns = dataset.feature_names + dataset.label_names
+        train_df = pd.DataFrame(data=data, columns=columns)
+
+
+        x_train = dataset.features
+        y_train = np.array([1 if y == [1] else -1 for y in dataset.labels])
+        x_control_train = np.array(train_df[self.sensitive_attr])
+        #print(x_train, y_train, x_control_train)
+
+        # privileged_vals = [1 for x in dataset.protected_attribute_names]
+        all_sensitive_attributes = dataset.protected_attribute_names
+
+        if not self.sensitive_attr:
+            self.sensitive_attr = all_sensitive_attributes[0]
+
+        if not self.class_attr:
+            self.class_attr = dataset.label_names[0]
+        model_name = self._runTrain(x_train, y_train, x_control_train)
+
+        #print(model_name)
+        self.model_name = model_name
+        return self
+
+    def predict(self, dataset):
+        """Obtain the predictions for the provided dataset using the learned classifier
+        model
+
+        Args:
+            dataset (BinaryLabelDataset): Dataset containing labels that needs
+                to be transformed.
+        Returns:
+            dataset (BinaryLabelDataset): Transformed dataset.
+        """
+
+        data = np.column_stack([dataset.features, dataset.labels])
+        columns = dataset.feature_names + dataset.label_names
+        test_df = pd.DataFrame(data=data, columns=columns)
+        x_test = dataset.features
+        y_test = np.array([1 if y == [1] else -1 for y in dataset.labels])
+        x_control_test = np.array(test_df[self.sensitive_attr])
+
+        all_sensitive_attributes = dataset.protected_attribute_names
+ 
+        predictions, scores = self._runTest(x_test, y_test, x_control_test)
+
+        pred_dataset = dataset.copy()
+        pred_dataset.labels = predictions
+        pred_dataset.scores = scores
+
+        return pred_dataset
+
+    def _runTrain(self, x_train, y_train, x_control_train):
+        obj = FalseDiscovery()
+        return obj.getModel(self.tau, x_train, y_train, x_control_train)
+
+    def _runTest(self, x_test, y_test, x_control_test):
+        model = self.model_name
+        obj = FalseDiscovery()
+        y_test_res = []
+        y_scores = []
+        for x in x_test:
+            t = model(x)
+            if t > 0 :
+                y_test_res.append(1)
+            else:
+                y_test_res.append(0)
+            y_scores.append((t+1)/2)
+
+        return np.array(y_test_res),np.array(y_scores)
+

--- a/aif360/algorithms/inprocessing/meta_fair_classifier.py
+++ b/aif360/algorithms/inprocessing/meta_fair_classifier.py
@@ -16,7 +16,7 @@ from aif360.algorithms import Transformer
 from aif360.algorithms.inprocessing.celisMeta.FalseDiscovery import FalseDiscovery
 from aif360.algorithms.inprocessing.celisMeta.StatisticalRate import StatisticalRate
 
-class MetaFairClassifer(Transformer):
+class MetaFairClassifier(Transformer):
     """The meta algorithm here takes the fairness metric as part of the input
         and returns a classifier optimized w.r.t. that fairness metric.
 
@@ -26,18 +26,18 @@ class MetaFairClassifer(Transformer):
 
     """
 
-    def __init__(self, tau=0.8, sensitive_attr="", class_attr="", type="fdr"):
+    def __init__(self, tau=0.8, sensitive_attr="", type="fdr"):
         """
         Args:
             tau (double, optional): fairness penalty parameter
             sensitive_attr (str, optional): name of protected attribute
-            class_attr (str, optional): label name
+            type (str, optional): the type of fairness metric to be used. Currently "fdr" and "sr" are supported.
+                                To use another type, the corresponding optimization class has to be implemented.
         """
-        super(MetaFairClassifer, self).__init__(tau=tau,
-            sensitive_attr=sensitive_attr, class_attr=class_attr)
+        super(MetaFairClassifier, self).__init__(tau=tau,
+            sensitive_attr=sensitive_attr)
         self.tau = tau
         self.sensitive_attr = sensitive_attr
-        self.class_attr = class_attr
         if type == "fdr":
             self.obj = FalseDiscovery()
         if type == "sr":
@@ -69,8 +69,6 @@ class MetaFairClassifer(Transformer):
         if not self.sensitive_attr:
             self.sensitive_attr = all_sensitive_attributes[0]
 
-        if not self.class_attr:
-            self.class_attr = dataset.label_names[0]
         model_name = self.obj.getModel(self.tau, x_train, y_train, x_control_train)
 
 
@@ -92,8 +90,8 @@ class MetaFairClassifer(Transformer):
         columns = dataset.feature_names + dataset.label_names
         test_df = pd.DataFrame(data=data, columns=columns)
         x_test = dataset.features
-        y_test = np.array([1 if y == [dataset.favorable_label] else -1 for y in dataset.labels])
-        x_control_test = np.array(test_df[self.sensitive_attr])
+        #y_test = np.array([1 if y == [dataset.favorable_label] else -1 for y in dataset.labels])
+        #x_control_test = np.array(test_df[self.sensitive_attr])
 
         all_sensitive_attributes = dataset.protected_attribute_names
  

--- a/examples/demo_calibrated_eqodds_postprocessing.ipynb
+++ b/examples/demo_calibrated_eqodds_postprocessing.ipynb
@@ -861,7 +861,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "version": "2.7.14"
   }
  },
  "nbformat": 4,

--- a/examples/demo_meta_classifier.ipynb
+++ b/examples/demo_meta_classifier.ipynb
@@ -2,10 +2,22 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 29,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The autoreload extension is already loaded. To reload it, use:\n",
+      "  %reload_ext autoreload\n"
+     ]
+    }
+   ],
    "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "\n",
     "import sys\n",
     "sys.path.append(\"../\")\n",
     "from aif360.datasets import BinaryLabelDataset\n",
@@ -22,12 +34,104 @@
     "from aif360.algorithms.inprocessing.meta_fair_classifier import MetaFairClassifer\n",
     "from aif360.algorithms.inprocessing.celisMeta.utils import getStats\n",
     "from IPython.display import Markdown, display\n",
-    "import matplotlib.pyplot as plt\n"
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 30,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "### Meta-Algorithm for fair classification."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "The fairness metrics to be optimized have to specified as \"input\". Currently we can handle the following fairness metrics."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "Statistical Rate, False Positive Rate, True Positive Rate, False Negative Rate, True Negative Rate,"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "Accuracy Rate, False Discovery Rate, False Omission Rate, Positive Predictive Rate, Negative Predictive Rate."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "#### -----------------------------"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "The example below considers the case of False Discovery Parity."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display(Markdown(\"### Meta-Algorithm for fair classification.\"))\n",
+    "display(Markdown(\"The fairness metrics to be optimized have to specified as \\\"input\\\". Currently we can handle the following fairness metrics.\"))\n",
+    "display(Markdown(\"Statistical Rate, False Positive Rate, True Positive Rate, False Negative Rate, True Negative Rate,\"))\n",
+    "display(Markdown(\"Accuracy Rate, False Discovery Rate, False Omission Rate, Positive Predictive Rate, Negative Predictive Rate.\"))\n",
+    "display(Markdown(\"#### -----------------------------\"))\n",
+    "display(Markdown(\"The example below considers the case of False Discovery Parity.\"))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -41,7 +145,124 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 32,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "#### Training Dataset shape"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(34189, 18)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "#### Favorable and unfavorable labels"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(1.0, 0.0)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "#### Protected attribute names"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['sex', 'race']\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "#### Privileged and unprivileged protected attribute values"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "([array([1.]), array([1.])], [array([0.]), array([0.])])\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "#### Dataset feature names"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['race', 'sex', 'Age (decade)=10', 'Age (decade)=20', 'Age (decade)=30', 'Age (decade)=40', 'Age (decade)=50', 'Age (decade)=60', 'Age (decade)=>=70', 'Education Years=6', 'Education Years=7', 'Education Years=8', 'Education Years=9', 'Education Years=10', 'Education Years=11', 'Education Years=12', 'Education Years=<6', 'Education Years=>12']\n"
+     ]
+    }
+   ],
+   "source": [
+    "display(Markdown(\"#### Training Dataset shape\"))\n",
+    "print(dataset_orig_train.features.shape)\n",
+    "display(Markdown(\"#### Favorable and unfavorable labels\"))\n",
+    "print(dataset_orig_train.favorable_label, dataset_orig_train.unfavorable_label)\n",
+    "display(Markdown(\"#### Protected attribute names\"))\n",
+    "print(dataset_orig_train.protected_attribute_names)\n",
+    "display(Markdown(\"#### Privileged and unprivileged protected attribute values\"))\n",
+    "print(dataset_orig_train.privileged_protected_attributes, \n",
+    "      dataset_orig_train.unprivileged_protected_attributes)\n",
+    "display(Markdown(\"#### Dataset feature names\"))\n",
+    "print(dataset_orig_train.feature_names)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
@@ -156,132 +377,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "#### Training Dataset shape"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(34189, 18)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/markdown": [
-       "#### Favorable and unfavorable labels"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(1.0, 0.0)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/markdown": [
-       "#### Protected attribute names"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['sex', 'race']\n"
-     ]
-    },
-    {
-     "data": {
-      "text/markdown": [
-       "#### Privileged and unprivileged protected attribute values"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "([array([1.]), array([1.])], [array([0.]), array([0.])])\n"
-     ]
-    },
-    {
-     "data": {
-      "text/markdown": [
-       "#### Dataset feature names"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['race', 'sex', 'Age (decade)=10', 'Age (decade)=20', 'Age (decade)=30', 'Age (decade)=40', 'Age (decade)=50', 'Age (decade)=60', 'Age (decade)=>=70', 'Education Years=6', 'Education Years=7', 'Education Years=8', 'Education Years=9', 'Education Years=10', 'Education Years=11', 'Education Years=12', 'Education Years=<6', 'Education Years=>12']\n"
-     ]
-    }
-   ],
-   "source": [
-    "display(Markdown(\"#### Training Dataset shape\"))\n",
-    "print(dataset_orig_train.features.shape)\n",
-    "display(Markdown(\"#### Favorable and unfavorable labels\"))\n",
-    "print(dataset_orig_train.favorable_label, dataset_orig_train.unfavorable_label)\n",
-    "display(Markdown(\"#### Protected attribute names\"))\n",
-    "print(dataset_orig_train.protected_attribute_names)\n",
-    "display(Markdown(\"#### Privileged and unprivileged protected attribute values\"))\n",
-    "print(dataset_orig_train.privileged_protected_attributes, \n",
-    "      dataset_orig_train.unprivileged_protected_attributes)\n",
-    "display(Markdown(\"#### Dataset feature names\"))\n",
-    "print(dataset_orig_train.feature_names)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Train set: Difference in mean outcomes between unprivileged and privileged groups = -0.194402\n",
-      "Test set: Difference in mean outcomes between unprivileged and privileged groups = -0.194759\n",
-      "Train set: Difference in mean outcomes between unprivileged and privileged groups = -0.194402\n",
-      "Test set: Difference in mean outcomes between unprivileged and privileged groups = -0.194759\n"
+      "Train set: Difference in mean outcomes between unprivileged and privileged groups = -0.193944\n",
+      "Test set: Difference in mean outcomes between unprivileged and privileged groups = -0.195913\n",
+      "Train set: Difference in mean outcomes between unprivileged and privileged groups = -0.193944\n",
+      "Test set: Difference in mean outcomes between unprivileged and privileged groups = -0.195913\n"
      ]
     }
    ],
@@ -315,23 +421,83 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 35,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<aif360.algorithms.inprocessing.meta_fair_classifier.MetaFairClassifer at 0x110c21110>"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Get classifier without fairness constraints\n",
+    "biased_model = MetaFairClassifer(tau=0, sensitive_attr=\"sex\")\n",
+    "biased_model.fit(dataset_orig_train)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "('Training Accuracy: ', 0.7888209658077159, ', Training gamma: ', 0.8466343589061862)\n"
+      "('Accuracy : ', 3148, 14653, 0.7851634477581383)\n",
+      "('SR tau : ', 0.5128381178595508)\n",
+      "('FPR tau : ', 0.7945499159671334)\n",
+      "('FNR tau : ', 0.910501272336843)\n",
+      "('TPR tau : ', 0.7721613485851896)\n",
+      "('TNR tau : ', 0.986749402037707)\n",
+      "('AR tau : ', 0.8525978220135617)\n",
+      "('FDR tau : ', 0.5030017152658662)\n",
+      "('FOR tau : ', 0.3717552930362757)\n",
+      "('PPR tau : ', 0.5485001947798986)\n",
+      "('NPR tau : ', 0.827615343560593)\n",
+      "0.503001715266\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Apply the unconstrained model to test data\n",
+    "dataset_bias_test = biased_model.predict(dataset_orig_test)\n",
+    "\n",
+    "predictions = [1 if y == dataset_orig_train.favorable_label else -1 for y in list(dataset_bias_test.labels)]\n",
+    "y_test = np.array([1 if y == [dataset_orig_train.favorable_label] else -1 for y in dataset_orig_test.labels])\n",
+    "x_control_test = pd.DataFrame(data=dataset_orig_test.features, columns=dataset_orig_test.feature_names)[\"sex\"]\n",
+    "\n",
+    "acc, sr, unconstrainedFDR = getStats(y_test, predictions, x_control_test)\n",
+    "print(unconstrainedFDR)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "('Training Accuracy: ', 0.7350317353534763, ', Training gamma: ', 0.672899406837947)\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<aif360.algorithms.inprocessing.meta_fair_classifier.MetaFairClassifer at 0x10cdc9e50>"
+       "<aif360.algorithms.inprocessing.meta_fair_classifier.MetaFairClassifer at 0x110c27c10>"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -339,24 +505,24 @@
    "source": [
     "# Learn debiased classifier\n",
     "tau = 0.8\n",
-    "debiased_model = MetaFairClassifer(tau=tau, sensitive_attr=\"race\")\n",
+    "debiased_model = MetaFairClassifer(tau=tau, sensitive_attr=\"sex\")\n",
     "debiased_model.fit(dataset_orig_train)\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Apply the plain model to test data\n",
+    "# Apply the debiased model to test data\n",
     "dataset_debiasing_train = debiased_model.predict(dataset_orig_train)\n",
     "dataset_debiasing_test = debiased_model.predict(dataset_orig_test)\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
@@ -375,8 +541,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Train set: Difference in mean outcomes between unprivileged and privileged groups = -0.226253\n",
-      "Test set: Difference in mean outcomes between unprivileged and privileged groups = -0.228184\n"
+      "Train set: Difference in mean outcomes between unprivileged and privileged groups = -0.201319\n",
+      "Test set: Difference in mean outcomes between unprivileged and privileged groups = -0.195210\n"
      ]
     }
    ],
@@ -398,7 +564,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
     {
@@ -417,12 +583,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Test set: Classification accuracy = 0.789463\n",
-      "Test set: Balanced classification accuracy = 0.707496\n",
-      "Test set: Disparate impact = 0.267508\n",
-      "Test set: Equal opportunity difference = -0.342941\n",
-      "Test set: Average odds difference = -0.232800\n",
-      "Test set: Theil_index = 0.147200\n"
+      "Test set: Classification accuracy = 0.731932\n",
+      "Test set: Balanced classification accuracy = 0.716763\n",
+      "Test set: Disparate impact = 0.539856\n",
+      "Test set: Equal opportunity difference = -0.120467\n",
+      "Test set: Average odds difference = -0.117636\n",
+      "Test set: Theil_index = 0.128652\n"
      ]
     }
    ],
@@ -445,47 +611,61 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "('Accuracy : ', 3085, 14653, 0.7894629086193954)\n",
-      "('SR tau : ', 0.6335828819141526)\n",
-      "('FPR tau : ', 0.6651902296035078)\n",
-      "('FNR tau : ', 0.9344431946006749)\n",
-      "('TPR tau : ', 0.9435242131376297)\n",
-      "('TNR tau : ', 0.9466027927717635)\n",
-      "('AR tau : ', 0.9175061708874659)\n",
-      "('FDR tau : ', 0.830043185477968)\n",
-      "('FOR tau : ', 0.5406237682301932)\n",
-      "('PPR tau : ', 0.8433187186542124)\n",
-      "('NPR tau : ', 0.924708780005249)\n"
+      "('Accuracy : ', 3928, 14653, 0.7319320275711458)\n",
+      "('SR tau : ', 0.5398556890759312)\n",
+      "('FPR tau : ', 0.6157226437750696)\n",
+      "('FNR tau : ', 0.7093999136230463)\n",
+      "('TPR tau : ', 0.8293479564733099)\n",
+      "('TNR tau : ', 0.8593163406441414)\n",
+      "('AR tau : ', 0.8892945217528149)\n",
+      "('FDR tau : ', 0.6832866118898019)\n",
+      "('FOR tau : ', 0.3834976405176844)\n",
+      "('PPR tau : ', 0.5596391928376183)\n",
+      "('NPR tau : ', 0.8967236467236467)\n",
+      "(0.6832866118898019, 0.5030017152658662)\n"
      ]
     }
    ],
    "source": [
     "### Testing \n",
-    "import numpy as np\n",
-    "import pandas as pd\n",
-    "\n",
     "predictions = list(dataset_debiasing_test.labels)\n",
     "predictions = [1 if y == dataset_orig_train.favorable_label else -1 for y in predictions]\n",
     "y_test = np.array([1 if y == [dataset_orig_train.favorable_label] else -1 for y in dataset_orig_test.labels])\n",
-    "x_control_test = pd.DataFrame(data=dataset_orig_test.features, columns=dataset_orig_test.feature_names)[\"race\"]\n",
+    "x_control_test = pd.DataFrame(data=dataset_orig_test.features, columns=dataset_orig_test.feature_names)[\"sex\"]\n",
     "\n",
     "acc, sr, fdr = getStats(y_test, predictions, x_control_test)\n",
-    "\n",
-    "# We give a 0.1 buffer since if the constraint might not be exactly satisfied if the \n",
-    "# normal distribution is not a good fit for the training data.\n",
-    "assert fdr >= tau - 0.1"
+    "print(fdr, unconstrainedFDR)\n",
+    "assert(fdr >= unconstrainedFDR)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "biased_model = MetaFairClassifer(tau=0, sensitive_attr=\"race\")\n",
+    "biased_model.fit(dataset_orig_train)\n",
+    "\n",
+    "dataset_bias_test = biased_model.predict(dataset_orig_test)\n",
+    "\n",
+    "predictions = [1 if y == dataset_orig_train.favorable_label else -1 for y in list(dataset_bias_test.labels)]\n",
+    "y_test = np.array([1 if y == [dataset_orig_train.favorable_label] else -1 for y in dataset_orig_test.labels])\n",
+    "x_control_test = pd.DataFrame(data=dataset_orig_test.features, columns=dataset_orig_test.feature_names)[\"race\"]\n",
+    "\n",
+    "acc, sr, unconstrainedFDR = getStats(y_test, predictions, x_control_test)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -505,122 +685,122 @@
      "output_type": "stream",
      "text": [
       "Tau: 0.10\n",
-      "('Training Accuracy: ', 0.7076837579338384, ', Training gamma: ', 0.8515484318287467)\n",
-      "('Accuracy : ', 4268, 14653, 0.7087285880024569)\n",
-      "('SR tau : ', 0.7542862733882257)\n",
-      "('FPR tau : ', 0.8029785756264359)\n",
-      "('FNR tau : ', 0.907716535433071)\n",
-      "('TPR tau : ', 0.973575036075036)\n",
-      "('TNR tau : ', 0.9123443457370778)\n",
-      "('AR tau : ', 0.9475531524465962)\n",
-      "('FDR tau : ', 0.8186068256194482)\n",
-      "('FOR tau : ', 0.520823267948594)\n",
-      "('PPR tau : ', 0.7309292649098476)\n",
-      "('NPR tau : ', 0.9523649427495581)\n",
+      "('Training Accuracy: ', 0.59007283044254, ', Training gamma: ', 0.8471557184765197)\n",
+      "('Accuracy : ', 6015, 14653, 0.5895038558656931)\n",
+      "('SR tau : ', 0.8607089248858592)\n",
+      "('FPR tau : ', 0.8957864358026685)\n",
+      "('FNR tau : ', 0.9194857234907978)\n",
+      "('TPR tau : ', 0.9919093179930415)\n",
+      "('TNR tau : ', 0.8974125546638897)\n",
+      "('AR tau : ', 0.9991230759162755)\n",
+      "('FDR tau : ', 0.8457246400235614)\n",
+      "('FOR tau : ', 0.5351545846135752)\n",
+      "('PPR tau : ', 0.6980432406212983)\n",
+      "('NPR tau : ', 0.972325603734294)\n",
       "Tau: 0.20\n",
-      "('Training Accuracy: ', 0.7143818187136213, ', Training gamma: ', 0.8740107239918714)\n",
-      "('Accuracy : ', 4167, 14653, 0.7156213744625675)\n",
-      "('SR tau : ', 0.6804186910415122)\n",
-      "('FPR tau : ', 0.7090519728192776)\n",
-      "('FNR tau : ', 0.7691338582677166)\n",
-      "('TPR tau : ', 0.9203232001159463)\n",
-      "('TNR tau : ', 0.8789558573886078)\n",
-      "('AR tau : ', 0.9233239855403916)\n",
-      "('FDR tau : ', 0.8362599159812782)\n",
-      "('FOR tau : ', 0.5883645137475918)\n",
-      "('PPR tau : ', 0.7659602999295992)\n",
-      "('NPR tau : ', 0.9585260144445069)\n",
+      "('Training Accuracy: ', 0.7089122232296938, ', Training gamma: ', 0.8560547557579788)\n",
+      "('Accuracy : ', 4219, 14653, 0.7120726131167678)\n",
+      "('SR tau : ', 0.6866930102717664)\n",
+      "('FPR tau : ', 0.6726467708167688)\n",
+      "('FNR tau : ', 0.9258698009067614)\n",
+      "('TPR tau : ', 0.9788702965603217)\n",
+      "('TNR tau : ', 0.8609042092761701)\n",
+      "('AR tau : ', 0.9016318454549019)\n",
+      "('FDR tau : ', 0.8985716754370806)\n",
+      "('FOR tau : ', 0.5212835077229696)\n",
+      "('PPR tau : ', 0.8634340785883854)\n",
+      "('NPR tau : ', 0.9509873699572469)\n",
       "Tau: 0.30\n",
-      "('Training Accuracy: ', 0.7259352423294042, ', Training gamma: ', 0.8537125021298012)\n",
-      "('Accuracy : ', 3988, 14653, 0.7278373029413772)\n",
-      "('SR tau : ', 0.7330044689928891)\n",
-      "('FPR tau : ', 0.7827902432716137)\n",
-      "('FNR tau : ', 0.9027438628994905)\n",
-      "('TPR tau : ', 0.9642543907434846)\n",
-      "('TNR tau : ', 0.9189050747980114)\n",
-      "('AR tau : ', 0.9406544636475846)\n",
-      "('FDR tau : ', 0.816026633595986)\n",
-      "('FOR tau : ', 0.5304400418327446)\n",
-      "('PPR tau : ', 0.7449500063116703)\n",
-      "('NPR tau : ', 0.9470110473041506)\n",
+      "('Training Accuracy: ', 0.7305566117757174, ', Training gamma: ', 0.8652540142403449)\n",
+      "('Accuracy : ', 3971, 14653, 0.7289974749198116)\n",
+      "('SR tau : ', 0.6378556299285792)\n",
+      "('FPR tau : ', 0.6258949415833267)\n",
+      "('FNR tau : ', 0.8021281808953761)\n",
+      "('TPR tau : ', 0.9157061270745418)\n",
+      "('TNR tau : ', 0.8661540136913607)\n",
+      "('AR tau : ', 0.9010399037361635)\n",
+      "('FDR tau : ', 0.8970117068060988)\n",
+      "('FOR tau : ', 0.6040206475603341)\n",
+      "('PPR tau : ', 0.8695616726701354)\n",
+      "('NPR tau : ', 0.9531107873071419)\n",
       "Tau: 0.40\n",
-      "('Training Accuracy: ', 0.7291526514375969, ', Training gamma: ', 0.87324761369921)\n",
-      "('Accuracy : ', 3933, 14653, 0.7315908005186651)\n",
-      "('SR tau : ', 0.6360982831029656)\n",
-      "('FPR tau : ', 0.6557415047511852)\n",
-      "('FNR tau : ', 0.7532376100046317)\n",
-      "('TPR tau : ', 0.8911200004359886)\n",
-      "('TNR tau : ', 0.877572625280048)\n",
-      "('AR tau : ', 0.9127393716667752)\n",
-      "('FDR tau : ', 0.8453463181953691)\n",
-      "('FOR tau : ', 0.6022250809986659)\n",
-      "('PPR tau : ', 0.7933303940889317)\n",
-      "('NPR tau : ', 0.9547231923986377)\n",
+      "('Training Accuracy: ', 0.6383339670654304, ', Training gamma: ', 0.8874069404811007)\n",
+      "('Accuracy : ', 5277, 14653, 0.6398689688118474)\n",
+      "('SR tau : ', 0.6738297875613554)\n",
+      "('FPR tau : ', 0.644122920953404)\n",
+      "('FNR tau : ', 0.7865711339087011)\n",
+      "('TPR tau : ', 0.9673632005976219)\n",
+      "('TNR tau : ', 0.7621665735103976)\n",
+      "('AR tau : ', 0.8627152073258121)\n",
+      "('FDR tau : ', 0.9207857965052172)\n",
+      "('FOR tau : ', 0.5333710407239819)\n",
+      "('PPR tau : ', 0.869572944869857)\n",
+      "('NPR tau : ', 0.9685594512195121)\n",
       "Tau: 0.50\n",
-      "('Training Accuracy: ', 0.7821521542016439, ', Training gamma: ', 0.8574042843302594)\n",
-      "('Accuracy : ', 3195, 14653, 0.7819559134648195)\n",
-      "('SR tau : ', 0.6765500013554587)\n",
-      "('FPR tau : ', 0.7134680978509129)\n",
-      "('FNR tau : ', 0.9827643852210782)\n",
-      "('TPR tau : ', 0.9875686745977381)\n",
-      "('TNR tau : ', 0.9467006553062615)\n",
-      "('AR tau : ', 0.920348482059736)\n",
-      "('FDR tau : ', 0.8263584179737061)\n",
-      "('FOR tau : ', 0.5143594749972882)\n",
-      "('PPR tau : ', 0.8266268964138297)\n",
-      "('NPR tau : ', 0.9242336242738334)\n",
+      "('Training Accuracy: ', 0.6278920120506596, ', Training gamma: ', 0.8424560564810398)\n",
+      "('Accuracy : ', 5474, 14653, 0.6264246229441071)\n",
+      "('SR tau : ', 0.8298481425555508)\n",
+      "('FPR tau : ', 0.8569955013034397)\n",
+      "('FNR tau : ', 0.928239074324443)\n",
+      "('TPR tau : ', 0.9916079407319798)\n",
+      "('TNR tau : ', 0.8873302430084463)\n",
+      "('AR tau : ', 0.9673097194084582)\n",
+      "('FDR tau : ', 0.8523093321100546)\n",
+      "('FOR tau : ', 0.4555634964843873)\n",
+      "('PPR tau : ', 0.7360851226839791)\n",
+      "('NPR tau : ', 0.9639178758413839)\n",
       "Tau: 0.60\n",
-      "('Training Accuracy: ', 0.7825323934598848, ', Training gamma: ', 0.8554832304502037)\n",
-      "('Accuracy : ', 3187, 14653, 0.7825018767487887)\n",
-      "('SR tau : ', 0.6801604075293094)\n",
-      "('FPR tau : ', 0.7195701276351641)\n",
-      "('FNR tau : ', 0.986495457298607)\n",
-      "('TPR tau : ', 0.9902334578535334)\n",
-      "('TNR tau : ', 0.9482780852625522)\n",
-      "('AR tau : ', 0.9211106754196199)\n",
-      "('FDR tau : ', 0.8237232744296363)\n",
-      "('FOR tau : ', 0.5134255457099633)\n",
-      "('PPR tau : ', 0.8244576911932922)\n",
-      "('NPR tau : ', 0.9239498336028926)\n",
+      "('Training Accuracy: ', 0.688964286758899, ', Training gamma: ', 0.8364392682037156)\n",
+      "('Accuracy : ', 4525, 14653, 0.6911895175049478)\n",
+      "('SR tau : ', 0.7999629846862536)\n",
+      "('FPR tau : ', 0.8174527554362845)\n",
+      "('FNR tau : ', 0.7909665888208081)\n",
+      "('TPR tau : ', 0.953958901547282)\n",
+      "('TNR tau : ', 0.9070827451204897)\n",
+      "('AR tau : ', 0.9394597060776729)\n",
+      "('FDR tau : ', 0.8613593842228706)\n",
+      "('FOR tau : ', 0.4055043530080791)\n",
+      "('PPR tau : ', 0.7937196009266697)\n",
+      "('NPR tau : ', 0.9433076267447764)\n",
       "Tau: 0.70\n",
-      "('Training Accuracy: ', 0.7880019889438123, ', Training gamma: ', 0.8236660239606577)\n",
-      "('Accuracy : ', 3107, 14653, 0.7879615095884802)\n",
-      "('SR tau : ', 0.7388666842500354)\n",
-      "('FPR tau : ', 0.8125903372997396)\n",
-      "('FNR tau : ', 0.9463964707608775)\n",
-      "('TPR tau : ', 0.9586339909758471)\n",
-      "('TNR tau : ', 0.9693913785236763)\n",
-      "('AR tau : ', 0.9287326090184583)\n",
-      "('FDR tau : ', 0.7923873722053703)\n",
-      "('FOR tau : ', 0.4934019370460049)\n",
-      "('PPR tau : ', 0.7995087423891958)\n",
-      "('NPR tau : ', 0.9176068678992656)\n",
+      "('Training Accuracy: ', 0.758694316885548, ', Training gamma: ', 0.8794270410853803)\n",
+      "('Accuracy : ', 3569, 14653, 0.7564321299392616)\n",
+      "('SR tau : ', 0.6227876622165098)\n",
+      "('FPR tau : ', 0.5866903792182638)\n",
+      "('FNR tau : ', 0.9190407482450215)\n",
+      "('TPR tau : ', 0.9560780895648338)\n",
+      "('TNR tau : ', 0.890147909980094)\n",
+      "('AR tau : ', 0.896234124640508)\n",
+      "('FDR tau : ', 0.9343469954055406)\n",
+      "('FOR tau : ', 0.5509667897652915)\n",
+      "('PPR tau : ', 0.9298652703704154)\n",
+      "('NPR tau : ', 0.9372291956457304)\n",
       "Tau: 0.80\n",
-      "('Training Accuracy: ', 0.7888209658077159, ', Training gamma: ', 0.8466343589061862)\n",
-      "('Accuracy : ', 3085, 14653, 0.7894629086193954)\n",
-      "('SR tau : ', 0.6335828819141526)\n",
-      "('FPR tau : ', 0.6651902296035078)\n",
-      "('FNR tau : ', 0.9344431946006749)\n",
-      "('TPR tau : ', 0.9435242131376297)\n",
-      "('TNR tau : ', 0.9466027927717635)\n",
-      "('AR tau : ', 0.9175061708874659)\n",
-      "('FDR tau : ', 0.830043185477968)\n",
-      "('FOR tau : ', 0.5406237682301932)\n",
-      "('PPR tau : ', 0.8433187186542124)\n",
-      "('NPR tau : ', 0.924708780005249)\n",
+      "('Training Accuracy: ', 0.7235953084325368, ', Training gamma: ', 0.8054119984862806)\n",
+      "('Accuracy : ', 4059, 14653, 0.7229918787961509)\n",
+      "('SR tau : ', 0.854029993599877)\n",
+      "('FPR tau : ', 0.8938353737389849)\n",
+      "('FNR tau : ', 0.6857428917603186)\n",
+      "('TPR tau : ', 0.9027407287653024)\n",
+      "('TNR tau : ', 0.9581570773154029)\n",
+      "('AR tau : ', 0.9535764486010664)\n",
+      "('FDR tau : ', 0.8409937049267278)\n",
+      "('FOR tau : ', 0.37742963089855464)\n",
+      "('PPR tau : ', 0.7856525093953137)\n",
+      "('NPR tau : ', 0.9281236852587971)\n",
       "Tau: 0.90\n",
-      "('Training Accuracy: ', 0.7902249261458364, ', Training gamma: ', 0.8385275998938002)\n",
-      "('Accuracy : ', 3073, 14653, 0.7902818535453491)\n",
-      "('SR tau : ', 0.6393483420030692)\n",
-      "('FPR tau : ', 0.6752232647408157)\n",
-      "('FNR tau : ', 0.9397225346831646)\n",
-      "('TPR tau : ', 0.9478350033746951)\n",
-      "('TNR tau : ', 0.9489725581811307)\n",
-      "('AR tau : ', 0.9186356409377993)\n",
-      "('FDR tau : ', 0.8251506780512304)\n",
-      "('FOR tau : ', 0.5391870263914295)\n",
-      "('PPR tau : ', 0.8395321367866094)\n",
-      "('NPR tau : ', 0.9242720479007847)\n"
+      "('Training Accuracy: ', 0.7241217935593319, ', Training gamma: ', 0.8099147766891792)\n",
+      "('Accuracy : ', 4051, 14653, 0.7235378420801202)\n",
+      "('SR tau : ', 0.8381936758377602)\n",
+      "('FPR tau : ', 0.8732228179504548)\n",
+      "('FNR tau : ', 0.7206111743921992)\n",
+      "('TPR tau : ', 0.9125888094427421)\n",
+      "('TNR tau : ', 0.9504356649707367)\n",
+      "('AR tau : ', 0.9489248561688661)\n",
+      "('FDR tau : ', 0.8448827898766063)\n",
+      "('FOR tau : ', 0.39272980229352533)\n",
+      "('PPR tau : ', 0.791857698925242)\n",
+      "('NPR tau : ', 0.9297660413700446)\n"
      ]
     }
    ],
@@ -645,8 +825,8 @@
     "    \n",
     "    acc, sr, fdr = getStats(y_test, predictions, x_control_test)\n",
     "    \n",
-    "    ## Testing if constraint is satisfied\n",
-    "    assert fdr >= tau - 0.1\n",
+    "    ## Testing\n",
+    "    assert (tau < unconstrainedFDR) or (fdr >= unconstrainedFDR)\n",
     "    \n",
     "    accuracies.append(acc)\n",
     "    false_discovery_rates.append(fdr)\n",
@@ -656,7 +836,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -685,7 +865,7 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1cAAAHGCAYAAACYZ3E/AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAIABJREFUeJzs3XeYVFXSx/FvkSQpKhhQQcQccFEQAxgwp12MmMmiIuqu7mtYRV2zq6uCCSUKiIqoGFbFCCqIIoiYUJCMiGQkw3DeP6rHaYYJPTM9fbunf5/n6Wd6bt++XT3x1j116lgIARERERERESmbSlEHICIiIiIiUhEouRIREREREUkCJVciIiIiIiJJoORKREREREQkCZRciYiIiIiIJIGSKxERERERkSRQciUiIiIiIpIESq5ERERERESSQMmViEiMmY01sxB32z/qmCRxZjYq7nvXKOp4omJmM/P9HBd2mxl1rCIiFY2SKxERwMz2BI7Mt/myKGIRERGRzKTkSkTEXVrAtovNzFIeSQmYWfWoY5D0EkJoFEKw3Fu+xyzu1iiiEEVEKiwlVyIi7pLYxzXAi7H7uwPH5N/RzA41sxfMbJ6ZrTezRWb2sZm1KOE+f5ax5Tv+FtvNbGBcOdfRZjbczJYDP8Yev8DM3jezOWa22szWmdl0M+ttZjuV5D2Y2WNxr3V4vud9Fdu+1MxqFPbFLEk8+d7bUWY2JHb8xWb2ipntXMDxO5nZVDNba2Zfm9kphcVSSHzDzWyBmZ1RwGMvmdkUM6tWkmMm+LqPxr3XI/I99kVs+0oz29rM9jCzQWY2O/Y+l5nZd7Gv145JjKkk36uEf2ZFRLJSCEE33XTTLatvwBFAiN1eBU6N+7xPvn3PBjbEPR5/65DoPrH9RuVuz/caW2wHBsYdY1Hc/Zmxx3sX8noBmAJUS/Q9AI2BnNjnA+Ket3fcfk8W8zUtSTzx721pAft/kO/YHQrYZwPwe9znjYqJr0Usjo/ybT8h9vwTy+ln7eC4GHvGbd8zbvvA2Lbvi/gaHlSC1/zzeUn4XiX8M6ubbrrplo03jVyJiGxeEjgc+BBYFvv8PDPbCiA2UtMHqBJ77HZgJ6AecD4wPZF9khDvCnx+WA3g9Ni2ocDhsdepGnvNAbHH9s3dL5H4QgjTgTdjj19gZtvG7l8YF0OfYmJMKJ4CzMATjX3wZAngBDOrH4u/EnBv3P7tgG2AG4EdionpTyGEL4HngYNyt5lZVeAJ4OUQwgeJHqskQgiTgQmxT9uaWeXY/YvidutvZnWBA2Kf9wJqAdsDhwE9gOVJDKu03ysREclHyZWIZLXYCfUFsU/XAW+FEDaQl1xsC/w1dr8lUDd2f1QI4e4Qwu8hhMUhhOEhhE8S3KesbgshjAshrA0h/BDbNh+4BvgaWA0sADrGPWffErwHgEdjH2sA7WP3c79OE0IIk4qJMdF48rs9hDA9hDAV+DRu++5xz9sldv/rEMLgEMIfIYRHgTnFxJTfD8AOsUQG4Hpgt9hHAMysrZlNNrOJZnZ0/JPNLTGzhJO6mP6xjzsDrWP3c5OrabHvwVLyEvzTgH/hSc7aEMI9IYSSvteilPZ7JSIi+VQpfhcRkQrtVPyKPcBEoKF5D4tvyOsWeCk+ohU//+QHCpbIPsUp7m/z1/GfmFkd4DOgqHk4ufOjEoovhDDazL4GDgGuMLOPgANjD/ctKrgSxpPfT3H3V8Xdz23cUTdu29x8z50HNCgqtnymxD7ub96WvAfw7xDCXPDkCXgMOCaEMK2A5+8NrAghLIzfGHuehRA2FfK6Q4H/4u/pYjNbSN4oVX+AEMImM7sMeDr2OrfGHf874PRkJFhl/F7F0/mEiAgauRIRiS8JPBL4NnZ7OG77aWa2PX5FP1dha2Alsk+udbl3LNb1L3Zivkcxz1uT7/PW5J0cfwjUD94l7toyxtczbr/HY/dX48lBUUoST34b4u4X1BxhUdz93fI9tmsCx483FZ9btj8+UjcLT6Yws+3w5GtbYLiZ/Z+ZbWtmz5nZ92b2GV5GOT62/12xRhxv4k1GtmjC8eebCmEZMCL26Tn4HDJisTwXt99bQEN85OhvwF2xfQ4Cbivhey1MSb9Xpf2ZFRHJCkquRCRrmdk25JX8FaUaXhI3Blgc29bazP5lZjuY2XZmdpaZHZPgPrlmxd3PjeMa8sreErUx7v5aYJWZHRg7Vn4lie8F8pKxY2Mfh4UQViQxnpL6Gfg1dv8QM7ss1lnvH5Rs1IoQwnrgF6ArcB7QPVYSSghhKT5a9F4IoWkI4SF89HJSCOFAvCnI/xFLroBmeCJ0aQhhvxDCrxQttzSwDtA9dn9k/PPM7HG8wcZK4F3gFfKSm4Ylea9FKOn3Klk/syIiFZKSKxHJZueRV/I0LGy+BpABJ8fte2kIYQ1wOXknpPfiTReWAK8BjRPZJ+6Yz8fdH2Zmf+CjRflHpoozBsgtTTsDb3jxXUE7liS+WPLxVL5DFFkSWNJ4SipWandr3KZBseM/jM9TKqkfgebAiyGEj/M91hz4CiCWdO4Qm9tFrBRwAZsnV9eFEBJtNPEhMDt2P7ekrn++fa4C3sfLHdfjpao1Y4+NTPB1ilPS71WyfmZFRCokJVciks3iSwIHFfD4h/iJLcBRZtY4hPAa3lntRXwEZSOemIwmNocpkX1i+40GuuCjMevwUZTzgS9L8iZioyyn4XNnVsde807ggUL2Tyi+mKfJGy35MYQwJtnxlFQIYSDQGf96rcfLOM8BJpficNPwEZsbCnisGbHkCu/S9+f3JbbOVCNggpntBlQJIXy9xREKEUsSB8ZtWgS8kW+3B/Cv4e/492g1Pi/wWvJKNsukFD87SfmZFRGpqCwErfcnIiIFM7MD8KSlMj4y0yvikJLKzF4CGoQQjirgscXAfiGEhWbWDrga77Zo+AhOkxDC/mbWBrgyhHBaKmMXEZH0o5ErERHZgpmdbWY/450JK+Od+RIpCcw0zchbd+pPZtYYWBnXCXAYPoI0BR/hq8rmJYHj8x9DRESyj1qniohIQergLcDX4utNdQshrI42pOSKtSFvjJfabSa2kPLucZ+vpZDmJyGE28srRhERySwqCxQREREREUkClQWKiIiIiIgkQdaXBVaqVCnUqJHI4vMiIiIiIlKY1atXhxBCVg/eZH1yVaNGDVatWhV1GCIiIiIiGc3Msn7Nu6zOLEVERERERJJFyZWIiIiIiEgSKLkSERERERFJAiVXIiIiIiIiSaDkSkREREREJAmUXImIiIiIiCSBkisREREREZEkUHIlIiIiIiKSBEquREREREREkkDJlYiIiIiISBIouRIREREREUkCJVciIiIiIiJJoORKREREREQkCSJJrsysm5nNMLO1ZjbBzI4uYt+BZhYKuK3Kt9/VZvajma0xs5/MrF35vxMRERERERFXJdUvaGYXAD2BbsBnsY/vmNkBIYTZBTzlOuDmfNvGAJ/EHfMq4EHgcuALoAXQx8yWhhDeTP67EBEp3ooVsPXWYBZ1JCIiUqGEAGvXwqpVsHq1f6xVCxo2jDqyrGchhNS+oNkXwOQQwuVx26YCw0MItyTw/JZ4UtYyhDA2tm0s8EUI4R9x+/0XODyE0Kqo49WqVSusWrWqqF1ERErst99gv/2gc2f473+jjkZERFJu/XpPeuIToMI+T3Rb7uerV8OmTZu/XocOMGBAJG81l5mtDiHUijSIiKV05MrMqgHNgIfzPfQecFSCh7kc+D43sYrZClibb781QAszqxpC2FCaeEVESqt3b1i+HB55BNq0gWOOiToiERHZTE5OYolMaROgjRtLFk+1alCzpo9Axd/q1IFddtl8W0H77bVX+XydpERSXRZYD6gMLMi3fQFwYnFPNrM6QFsg/wjXSKCzmb0KfIUncF2AqrHXnJ/vOF2BrgDVqlUr8ZsQESnKunWeXB1/PMycCZ06wTff+P8+ERFJ0KZNsGZN+SVA69aVLJ5KlbZMaHITnXr1ik5+CkqG4rfVrAlVq5bP11FSKuVzrsroUrwJx+B82+8GdgbGAoYna88BNwL5xkwhhPAs8Cx4WWA5xisiWejll2HBAhg0yC9Etm4Nt94Kjz0WdWQiIim0YQMsWQKLFuXdFi/e/PMlS2DlyoIToDVrSv6ahSU19esnnugUtq1aNU2ilWKlOrlaBOQAO+XbvhPwWwLPvxx4JYSwJH5jCGEN0MnMrogdaz4+MvUHsLCsQYuIJCoE6NnT51uddJL/H776aujVC849F44utDeqiEga27ix+EQp/+fLlxd+vFq1fLRn++2hdu28kZ/SJj61akH16j66JBKhqBpafBNC6Bq37Wc8aSq0oYWZtcA7AbYOIYxK4HVGA/NCCBcXtZ8aWohIMn3+ORx1FDz5JHTr5ttWroQmTaBKFS8PrFkz2hhFJMvl5GyeKBWXJC1aBMuWFX683LK4evWgbt28+4Vtq1vXEyGpcNTQIpqywEeAwWb2Jd5S/UpgF6A3gJkNAggh5F+nqiswtaDEysz2AQ4HxgHbAdcDBwHty+ctiIgUrFcv2GYbaBf3F6x2bejf3+dg3XabN7kQEUmKnBxYujTxJGnxYt+/sIvr1avDDjvkJUGNGhWfONWokdK3LJLOUp5chRBeMrO6wG1AfeA74PQQwqzYLls06DezrYELgbsKOWxlPKHaF9gAfAwcFUKYmdzoRUQKN28eDB8O11zjCVW81q19JOuxx7w8sGXLaGIUkTS2aZMnPoUlRQV9vmRJ4YnSVlttnigdemjRo0n16mloXaSMUl4WmG5UFigiydKjB9x7L0ybBo0bb/l4bnlg1aowaZLOYUQqtE2bfM5RoklSbqKUf+2iXNWqbZ4oFVd2l5soqQGDpJDKApVcKbkSkaRYuxYaNoQjj4TXXy98v48+ghNOgOuv1+LCIhkpJwfGj4effio6cVq8uOhEqbjEKP/ntWopUZK0p+Qq81qxi4ikpRdfhIUL4dpri97v+OPhyivh0Ue9PPCoRJdPF5HozJ8PI0fCu+/Ce+956V6uqlU3T4QOPLD4RKl2bSVKIhWURq40ciUiZRQCNGvm61F+913x50x//AEHHeTzxidN0lxwkbSzfj2MGePJ1LvvwuTJvn3nneHUU/3WvLmX6W29tRIlkRiNXGnkSkSkzMaMga+/ht69EzvH2npr6NfP18G6/XZ46KHyj1FEijFjRl4y9dFHPkmyalVo1QoefNATqiZNlEiJSJE0cqWRKxEpo7Zt4YMPYM4cnxaRqCuugL594bPPfK6WiKTQ6tUwenReQvXzz769USM47TRPplq39qshIpIQjVwpuVJyJSJlMmcO7LGHN6j4z39K9twVK/xCeI0aPvKl8kCRchQC/Phj3typ0aO9lrd6dU+icsv99t5bo1MipaTkSmWBIiJl8vTTfs7WrVvJn7vNNj5ydfLJcMcdJU/ORKQYy5fDhx/mjU7NmePb99/ff2lPPRWOPlpXNkQkaTRypZErESmlNWugQQM45hh49dXSH6drV5+DNWYMHHFE8uITyTqbNnmXmNxkauxYb52+zTZw4olwyil+2333qCMVqZA0cqXkSsmViJRav37QpQt8/DEcd1zpj7NihXcPrFXLywOrV09aiCIV38KF8P77nkyNHAm//+7bDz00r9TviCO8OYWIlCslV0qulFyJSKmEAE2b+v1Jk8o+RWPkSD8HvOkmeOCBsscnUmFt3AhffJE3OjVhgv9C1q3ro1Knnuq1tjvtFHWkIllHyZWSKyVXIlIqo0f7aFXfvtC5c3KO2aULDBgAn38OLVok55giFcLcuXmNKN5/3+dSVarkI1K5o1OHHgqVK0cdqUhWU3Kl5ErJlYiUyrnnwqhRfs6XrLnwy5d7eeA22/jFeJUHStZat87XKMgdnfruO9++6655ydQJJ8B220Ubp4hsRsmVugWKiJTYzJkwYgTceGNym4zVqQN9+vgSO3fdBffdl7xji6S9adPykqmPP/Z1qKpV825+7dt7QnXggWqTLiJpTSNXGrkSkRK68UZ45BGYPh0aNkz+8Tt3hoEDYdw4OOyw5B9fJC2sXOnDv7kJ1S+/+PbGjfMW8T3uOKhdO8ooRaQENHKl5ErJlYiUyKpVsNtu3tX55ZfL5zWWLfPywDp1YOJE2Gqr8nkdkZQKAb7/Pi+Z+vRTWL8eatbcfBHfvfaKOlIRKSUlVyoLFBEpkeef9+TnuuvK7zW23RaefRbOOMPLA++9t/xeS6RcLV0KH3yQ14xi3jzfftBBcO213t2vVStNMBSRCkMjVxq5EpEEhQBNmvg0kAkTyn/qR8eOMHiwlwc2b16+ryWSFJs2+S9H7ujUuHG+rU4dOOkkH5k65RQf/hWRCkcjV0qulFyJSMI++sgblA0YAB06lP/rLV3qF/i33x6++krlgZKmFiyA997zZOq992DRIt/evHleqd/hh0MVFcuIVHRKrpRcKbkSkYS1aQNjx8KcOamrYvrf/+DMM+G22+Duu1PzmiJF2rDBF2PLLfWbONG377BD3iK+J50EO+4YbZwiknJKrpRcKbkSkYRMn+7z7P/1L7jnntS+docOMGQIfPmlr5MqknKzZ+eV+n34IaxY4Qv2HnVU3uhU06a+sK+IZC0lV0qulFyJSEJuuAF69fI1rnbdNbWvvXSpL+9Tr56XB1arltrXlyy0di188kleQvXjj769QYPNF/GtUyfaOEUkrSi5UnKl5EpEirVypc+/P+00eOGFaGJ4803429+gRw/vICiSVCHA1Kl5ydSoUbBmjWfyxx6bl1Dtv78W8RWRQim5UnKl5EpEivX009Ctm8+3OvLI6OJo1w6GDlV5oCTJH394l5bchGrmTN++9955ydSxx0KtrD5PEpESUHKl5ErJlYgUadMmL8mrXduTmigv2i9Z4rHsuCOMH6/yQCnCpk2wbp3f1q7Nu79sGXz8sSdTY8Z4c4patbzEL7dNeuPGUUcvIhkq0eTKzLoB/wfUB74H/h5C+LSI/S8GbgT2AVYAHwD/DCH8VsC+FwFDgf+FEM4s1RspA/VFFREpwgcfwJQpMGhQ9NVQ228PzzzjXQvvuw/uvDPaeCROCJ6o5CYx+ZOasm4r6fM2biw63oMPhn/8wxOqo45Sn38RSRkzuwDoCXQDPot9fMfMDgghzC5g/5bAYOCfwAhgJ+Ap4HnghHz7NgYeAgpN1MqbRq40ciUiRTjzTG8iMWtW+px/XnopvPSSj141bRp1NBHKyUle8lLWbevWeYKVDFWr+g/bVlt5z//c+0VtS3TfmjV9zalUd2URkayQyMiVmX0BTA4hXB63bSowPIRwSwH7/xO4JoSwe9y2jsDjIYTacduq4snaU0BroJ5GriKw/fbbM2rUqKjDEJE0NHduDf73v8Np334mn38+M+pw/tS2bRXefrsF5523nt69J1ClSgW/SLZoEfz2m5e6hZD3sazJTOXKnmzUrOktxM0K/1jUY8net7xNneo3EZHkq2JmX8V9/mwI4dncT8ysGtAMeDjf894DjirkmGOA+8zsr8BbQF3gQuDtfPvdC8wMITxnZq3L8B7KJOuTqyVLlnDcccdFHYaIpKG//90HEe6/vxH16zeKOpzNDBgAZ51VjbFjj+X226OOphzl5ECjRlCjhjdXKOmITiKjPFWy/l+hiEiybAwhNC/i8XpAZWBBvu0LgBMLekII4XMzuxAvA6yB5y/vA+1z9zGzk4G2QOT1HPqPIiJSgBUroH9/aNsW6tePOpottWkDF18Md9/t9//yl6gjKicffABz53odZNu2UUcjIiIpZmYHAI8DdwMj8SYYDwHPAO3MbAdgIHBRCGFZVHHmUnIlIlKA557zTtXXXht1JIXr1ctzjw4dvJNh1apRR1QO+vWDunU9gxQRkUy3CMjBm1LE2wnYovNfzC3AlyGEh2KfTzazVcCnZvYvYC884frQ8kqrKwGY2UbgwBDCT8l7C0WrlKoXEhHJFJs2weOP+7z/Fi2ijqZwdetC794waRI88EDU0ZSDRYtgxAjv4JEu3URERKTUQgjrgQnASfkeOgkYW8jTauIJWbzczysB44EmeElg7u0NvGNgU2BGmQMvAY1ciYjkM3Kkz/cfOjTqSIp39tlw4YV55YEHHxx1REk0ZIi3N+/cOepIREQkeR4BBpvZl3iziiuBXYDeAGY2CCCE0C62/5tAHzO7iryywMeAiXGt27+LfwEzWwZUCSFstj0VIhm5MrNuZjbDzNaa2QQzO7qIfQeaWSjgtirffheb2SQzW21mv5nZEDPbufzfjYhUNL16+Tyrc8+NOpLEPP44bLcddOzouUiFEIKXBDZvDk2aRB2NiIgkSQjhJeDvwG3AJKAVcHoIYVZsl4axW+7+A4Hrge54EjUc+BlIy3rxlK9zFVs4bAibLxzWEShs4bA6eGeQeGOAT0IIHWP7tAQ+YcvFxZaGEE6gCFrnSkTi/fQT7Lcf3HUX9OgRdTSJe/VVTwbvuQduvTXqaJJg/HivyXz6abjyyqijERGRBCSyzlVFF0VyVaKFwwp4fks8KWsZQhgb25bQ4mIFUXIlIvG6d4c+fWD2bNgp/3TbNHfhhZ5kTZwIBx0UdTRldOWVMGgQzJ8PdepEHY2IiCRAyVWKywLjFg57L99DRS0clt/lwPe5iVXMGKC+mf3VXD0KXlwsN46uZvaVmX21cePGkr0JEamwli+HgQM9Scm0xAq8PHDbbb17YEaXB65eDS+8AOedp8RKREQySqrnXBW1cFix86NiJYJtgT7x20MIn+PJ1PPAemAhYMQtLpZv/2dDCM1DCM2raPFIEYkZMABWrUrv9utF2WEHeOopmDABHnqo+P3T1vDhvtBYp05RRyIiIlIimdaK/VI85sHxG/MtLtYMOBVP1p5JdYAikplycnzkp2VLaNYs6mhK77zz4Pzz4c474buU90hKkv79Yc894dhjo45ERESkRFKdXJVm4bB4lwOvhBCW5Nv+5+JiIYTJIYSReKOMy8xst7IGLSIV3zvvwPTpmTtqFe+JJ7yarmNHyLjK52nTYPRoH7XKWwxSREQkI6Q0uSrlwmEAmFkL4C/kKwmMKW5xMRGRIvXsCbvu6utGZbodd4Qnn4SvvoKHH446mhLq3x8qVYL2BVZ1i4iIpLUoEo9HgA5m1sXM9jeznuRbOCx38bB8ugJTQwijCnjsTaCNmV1lZo1jHQV7sfniYiIiBfrhB/jgA+jWDapWjTqa5Gjb1ksE77jD319G2LjRO4qcdppnuiIiIhkm5clVSRcOAzCzrfGGFX0LOeZAMmhxMRFJL48/DlttBZdfXvy+meTJJ2HrrTOoPPDdd731uhpZiIhIhkr5OlfpRutciWS3pUtht928/Xq/flFHk3wvveTv7YEH4Kaboo6mGOecA599BnPnQrVqUUcjIiIlpHWuNB9JRLJc//6+rNI110QdSflo29ZzlttvT/PywAUL4M03oV07JVYiIpKxlFyJSNbKyfHOesccA02bRh1N+TDzta9q107z8sDBgz04lQSKiEgGU3IlIlnrzTdh5syK0X69KDvt5Enkl1/Co49GHU0BQvCazCOOgAMOiDoaERGRUlNyJSJZq1cvaNAA2mRB65sLL4SzzoIePWDKlKijyWfcOA+qc+eoIxERESkTJVcikpW+/RY+/hiuvhqqVIk6mvJnBk8/DbVqeXlgTv6VAaPUr58HdsEFUUciIiJSJkquRCQrPf441KhR8dqvF2Xnnf19jxsHjz0WdTQxK1d6S8O2bb1vvIiISAZTciUiWWfxYhgyBC69FLbfPupoUuuii7wM8rbb4Kefoo4GGDbMEyyVBIqISAWg5EoqhJwc6NoVnnsu6kgkE/TtC2vWVNz260XJLQ+sUSNNygP79YN994Wjjoo4EBERkbJTciUVwoMPQp8+cOWVMH161NFIOtu4EZ58Elq3hiZNoo4mGvXrezOPzz+Hnj0jDGTKFBg71tuvm0UYiIiISHIouZKM9+WXcMcdcPrpULUqdOvmnZ1FCvL66zBnTsVvv16cSy6Bv/4Vbr0Vfv45oiD694fKlX3hYBERkQrAQpafhdaqVSusWrUq6jCklP74Aw45xEcjJk3ydUivvRZeeMFbT4vkd+yxMHs2TJvm5/XZ7Ndf4cAD/TZ6dIq/Hhs2wG67wZFHwogRKXxhEREpL2a2OoRQK+o4oqSRK8lo114LM2Z4c4Jtt/VRq+bN4e9/h2XLoo5O0s2kSfDJJ9C9uxIrgF128bLAMWO8i2BK/e9/8PvvXhIoIiJSQSi5kow1bBgMHOhlTa1a+bbKleGZZ2DhQrjllkjDkzTUqxfUrKnz+XiXXQZnngn/+hdMnZrCF+7f33vDn356Cl9URESkfCm5kow0a5Z3BzziCLj99s0fO/RQuO466N3bJ+yLgCfcQ4f69J7ttos6mvRh5hckttrKk85Nm1LwovPnw9tvQ/v22bGCs4iIZA0lV5JxcnL8avumTfD88wWfm911l0/nuOIKn9oh0qcPrFuXne3Xi7PLLr6o8Gefpag88Lnn/BdZQ4giIlLBKLmSjHP//fDpp95Ou3HjgvepXRueeAK+/RYefTS18Un62bABnnoKTjoJDjgg6mjSU7t2XqF3yy3e7KPchOAlgUcfDfvsU44vJCIiknpKriSjjBsHd94JF10El15a9L5t2sBZZ/n+M2akIjpJV6+9BvPmqf16Uczg2WehWrVyLg/89FOf3KVRKxERqYDUil2t2DPGihXedj0nB775BurUKf45c+b4SMUxx8Bbb2md0mzVqhX89puv51RJl5SKNGCA5z29epVTCWWHDvDqqz7vqlZWd+sVEalw1IpdI1eSQa65BmbO9HlWiSRWAA0awN13+9z54cPLNTxJUxMmeKvx7t2VWCWiQwc47TS4+Wb45ZckH3zFCnj5ZV+ETomViIhUQDrVkIzw4oswaBDcdhu0bFmy53bv7h0Er70Wli8vn/gkffXq5efxHTtGHUlmyC0PrFIFOndOcnngiy/C6tV+YBERkQpIyZWkvVmz4Mor4cgjoUePkj+/ShVvNf37774mlmSPBQv8fL5Dh8RHO8U7bT76KIwe7Y1AkqZJQNtHAAAgAElEQVRfPzjwQGjRIokHFRERSR9KriStbdzojSuKarueiObNfQTrqafgiy+SG6Okr2efhfXr1X69NDp2hFNOgZtugunTk3DA776DL7/0CV2a/CgiIhWUkitJa/ff72vvPPUU7LFH2Y51992+ns8VV3jSJhXb+vXw9NNw6qmw775RR5N5zHxtsMqVk1Qe2L8/VK3qi9SJiIhUUEquJG19/jn8+99w8cXFt11PxDbb+Pybb76Bnj3LfjxJb8OHe0M6tV8vvQYN4JFHYNQo6N27DAdavx4GD4a//Q122CFZ4YmIiKQdtWJXK/a0tGIFNG3q641OmpS8+TIh+PpXH34IP/wAu++enONK+jniCFiyBKZMUZfAsgjBywPHjvVFuUs1gjx8OJx/vrftPO20pMcoIiLpQa3YNXIlaap7d29kMWRIchsRmMETT/jH7t39xFEqni++8Ns11yixKisz6NvXv46lLg/s1w923RVOPjnp8YmIiKQTnXZI2nnhBa8g6tGj5G3XE9GwoZcbvvUWvPZa8o8v0Xv8cdh6a+8SKGXXsCH897/w8cfeJKRE5syBkSP9m1G5cnmEJyIikjZUFqiywLQycyb85S9w0EHeBrq03QGLs3GjdxBcuBB+/NHnY0nFMH++l3t26waPPRZ1NBVHCD7wNG6clwc2apTgE++5x6+U/PILNG5cniGKiEjEVBaokStJI7lt18HLAcsrsQI/9rPP+on4bbeV3+tI6j3zjP8sde8edSQVS255IHh5YELX5TZt8i6BrVsrsRIRkayg5ErSxn33wZgxyWm7nogWLXx044knYPz48n89KX/r1nn79dNPh732ijqaimf33eHhh+GjjxIsDxw1CmbM8GxMREQkC6gsUGWBaeHzz+Hoo+HCC33UKlWWL4f994edd/b1TctztEzK3+DB0K6dT/FR74TyEQKceKL/vnz3XTEdNy+91Cc3zp8PNWqkLEYREYmGygIjGrkys25mNsPM1prZBDM7uoh9B5pZKOC2qiT7SPpasQIuucTX1HnyydS+dp06vvbV1197EwTJXCH4+mX77QcnnRR1NBWXmTf/CwG6dCmiPHDZMnjlFV+oTomViIhkiZQnV2Z2AdATuA84BBgLvGNmDQt5ynVA/Xy36cCwEu4jaerqq2H2bHj++eS2XU/Uued6GVmPHt7YTDLTuHEwYYIvGmwWdTQVW6NG8NBD8MEHefOwtjB0KKxdq5JAERHJKikvCzSzL4DJIYTL47ZNBYaHEG5J4Pktgc+AliGEsaXdJ5fKAqM1dKiPWt15J9xxR3RxzJwJBxzgpWQjRkQXh5TeRRfBO+/A3LlQu3bU0VR8mzb5COH48V4e2DD/5bFmzSAnx4eFle2KiGQFlQWmeOTKzKoBzYD38j30HnBUgoe5HPi+mKQpkX0kYjNmwFVX+VpWt94abSyNGvnaV6+/ruQqE82bB8OH+yCJEqvUqFTJR602bSqgPHDSJJg4ETp1UmIlIiJZJdVlgfWAysCCfNsXADsX92QzqwO0BfqUcZ+uZvaVmX21cePGROKWJEtl2/VE/f3v0KQJXHMN/PFH1NFISTz9tA+SXH111JFklz32gP/8B95/3+dh/al/f6hWzYelRUREskimtWK/FI95cFn2CSE8G0JoHkJoXiUdzuqz0L33wtixflKc8GKk5axqVV8jad48uP32qKORRK1d69+3v/5VSylF4cor4bjj4Prrfe4ka9f6FZOzz4a6daMOT0REJKVSnVwtAnKAnfJt3wn4LYHnXw68EkJYUsZ9JEJjx8Jdd/nI1cUXRx3N5o480k8We/XyqiZJfy++CIsWwXXXRR1JdqpUyUetcnKga1cIr42ApUvVyEJERLJSVA0tvgkhdI3b9jOeEBXa0MLMWgBfAK1DCKNKu09+amiRWsuXQ9OmPg1j0iTYZpuoI9rSsmW+9tWuu8IXX0DlylFHJIUJwfsmrF8P336r6T1ReuIJL6ntt//DdFr1uE+qrJRpxREiIlIWamgRTVngI0AHM+tiZvubWU9gF6A3gJkNMrNBBTyvKzC1mKQpkX0kQldf7e3On38+PRMrgG23hcce87beqV53S0pmzBhvRqf269Hr1g2OPXwt//jxcuaee50SKxERyUop/+8XQngJ+DtwGzAJaAWcHkKYFdulYez2JzPbGrgQKGxFlYT2kWg9/7zfbr/dy+/SWdu2cOqp3sVw7tyoo5HC9OwJ222nvgnpoFIl6NfiGTZSha5fX1X44sIiIiIVWMrLAtONygJTY8YM+Mtf4OCDYdSo9OgOWJzp0+HAA32B4VdeiToayW/2bG9gcf313rFOIpaTA40b83iNG7n2p6vp3x86dow6KBERSSWVBWZet0DJQBs3+siCWfq0XU9E48a+sPGrr8Ibb0QdjeT39NM+50rt19PEhx/C7NlcfUc9jj4a/vEPjfqKiEj20ciVRq7K3Z13+gK9Q4fCRRdFHU3JbNgAhx7qjTh++EEL1KaLNWtgt928BbhGFdPEhRfCe+/Br78ybW51Dj4YWreGt97SfDgRkWyhkSuNXEk5GzMG7r4bLrss8xIryFv7as4cTxIlPQwdCkuWeCMLSQOLF8Nrr/n6CtWrs9decP/98PbbMKig9kQiIiIVlJIrKTfLl3s5YKNG3qY5Ux11lK/f89hj3plOohWCN7I4+GA45piooxHAO9WsX7/Z2lbXXAOtWvn6Y/PmRRibiIikHTPrZmYzzGytmU0ws6OL2f9iM5tkZqvN7DczG2JmO8c9fr6ZfWVmy8xsVWzf9uX/Trak5ErKTbduPucinduuJ+qBB6BuXbjiCp+3L9EZPdrXtFL79TQRgq8i3KyZd62JqVQJ+vf3nOuKK1D3QBERAcDMLgB6AvcBhwBjgXfMrGEh+7cEBgPPAQcCZwEHAM/H7bYYuAc4AjgYGAD0M7PTy+ltFErJlZSLIUO8dOuOO+CII6KOpuy22w4efRTGj4fevaOOJrv16uWJ7sUXRx2JAL4g3OTJm41a5dp7b7jvPvjf//xvgohIvBC8M68uvmSd64GBIYQ+IYQfQwjXAPOBqwrZ/0hgbgjh0RDCjBDCOOBx4PDcHUIIH4UQRoQQpoQQfgkh9AQmA0WOiJUHJVeSdNOn+6hVq1bwr39FHU3yXHQRnHQS3HIL/Ppr1NFkp5kz4fXXvUyzRo2ooxHAh6eqVy90UuU110DLlj7SqN8bEYn3+uuw555+Ieb++/U3IhuYWTWgGfBevofeA44q5GljgPpm9ldz9fC1bd8u5DXMzE4A9gU+SU7kicv6boENGjQIgwcPjjqMCiMnx7juuqbMnFmLvn3Hs/PO66IOKanmzatOp06HceSRi7nzzh+iDifr9O7dmJdfbsALL4xjxx0r1s9WRgoBvvkG6tSBPfYodLc5c2rQpUtzmjVbyr33fqdyThEB4I47DuSbb+rQqNFqvvlmWypVChx++GJOP/03jjhiMVWqZPc5aiZq3br1euDbuE3PhhCezf3EzHYB5gHHhhA+idt+O3BJCGHfgo5rZucAA4EaQBXgfaBNCGFN3D51YsfeCsgBrg4h9EvSW0tYhqw4VH6WLFnCcccdF3UYFcYdd8D338MLL8CFFx4ZdTjlYuZMuO22HVm1akfOOCPqaLLHqlVw9tlw7rnQtm3F/NnKOEOG+IJWH33kffGLsHAh3HBDPebNO45LL01NeCKSvlauhC+/hC5d4PHHqzFtGvTvbwwcWI8ePeqx007Qvj106gT7Fni6LWlqYwiheTIPaGYH4GWAdwMjgfrAQ8AzQLu4Xf8AmgK1gROAR8xsZgjhw2TGU2y82T5ypXWukuezz+DYY70b83PPRR1N+Vm/Hpo2hdWrPZGsldWrOaTOM8/AlVfCp596yamkgdatYfZsmDrVO1gUIScHjj4apkzx35v69VMUo4ikpZde8uXxRo/evPPrxo3wzjveJ+ett/xvR6tWnoSdd57+56a74ta5ipUFrgYuCiG8HLf9SeCgEMKxBTxnMFA7hHB23LZWwKdAgxBCgUvWm1lfYI8QwgmlfkOloDlXkhTLlnlSlelt1xNRrZqf6M+a5YsjS/kLwRtZHHKIz9+RNPDLLzBqlF9WLiaxAqhcGQYM8IsSV16pCewi2W7YML/Ikv9vepUq8Ne/wogRvsbkAw/AggXQoYPvf8UVPuKlvyGZKYSwHpgAnJTvoZPwroEFqYmX+cXL/byof0CV8BLBlFJyJWUWQl7b9aFDYeuto46o/B19tDdHe+QRb5Qm5eujj+CHH9R+Pa0MGOBJVfvElxHZd1+45x544w0vHRaR7PTHH77I+Hnn+YWXwtSvDzfdBD/9BJ98AuecA4MHw+GH+8oPPXv6GuaScR4BOphZFzPb38x6ArsAvQHMbJCZxS9B/ybQxsyuMrPGsdbsvYCJIYTZsefcamYnxh7f38xuAC4DUt6rVmWBKgsss8GDoV07uPtuuO22qKNJnSVLYL/9oHFjGDs2oYv3Ukpt2sDnn3sFWvXqUUcj5OTA7rv7Ss5vF9isqcintmoFP//s5YE771z8c0SkYnnhBV9OozRl3suXw4svetng+PFeTXLWWX7B88QT9b84asWVBcbt1w24EZ8/9R3wj9wGF2Y2CiCEcFzc/tcAVwJ7AMuBj4CbcksCzex+4DxgN2ANMAV4PISQ8kt5Sq6UXJXJ9Ok+/6hpU/j446KvQFVEQ4bAZZfBU0/BVYWtziBlMn067LUX3HqrJ/CSBt5+G844A4YP9w4jJTRliv/NOO00ePVVjUaKZJuzz/bSvjlzypYMTZ7sSdaQIX7Bc/fdoWNHvzUscDlaKW+JJlcVmfJ7KbUNG+CSS/wP45Ah2ZdYgb//E07wta/mz486morpiSf8Z+vKK6OORP7Urx/Uq+cTI0phv/08UR4xwq9Ai0j2+OMPb1hx3nllH2U6+GAvDZw3z/+W7LMP3Hmnz/8+5RR4+WVYp1U7JMWUXEmp3X03jBvnzR2y9QqRmY9arV3rHakluVau9PP4886DXXeNOhoBvKf6G2/4kG21aqU+zPXX+7yJ7t19srqIZIc33/SEp23b5B2zenW44AJ47z2YMQN69IAff/TX2HVX///83XfJez2Roii5klL59FO4916fy37BBVFHE6199vGStZdegnffjTqaimXQIFixwhtZSJoYPNh7JXfuXKbD5HYPXLXKS2qzvEJdJGsMG+YJz5HltFxho0beyXfGDB8ha90annwSmjSBI46APn189EykvGjOleZcldiyZd6lp2pV+Prr7OgOWJx16/xrsn69Xx2rWTPqiDLfpk1w4IH+8/XFF5qXkxZCgIMO8m/KuHFJOeSDD8LNN3tJT7ZfqBGp6FasgB128A7Djz6autdduNCnL/Tr5410atb0Ua0uXeCoo/T/JZk050ojV1JCIfhV5nnz4PnnlVjl2morL4+cMUNNF5Llgw+88YHar6eRL77wnvhlHLWKd8MNcNhhcPXV8PvvSTusiKShN97wi5Dnn5/a191hBy8N/PZb7zx78cXej6dVK9h/f3joIZUnS/Jo5EojVyUyaJCXAt5zj5fCyeY6dfKqqa+/9gv8UnpnnAETJvhizVulfAlAKVDXrn5VZf582GabpB32hx98gei//c0noItIxdSmDUyc6H/Xo26ZvnKllyj26+fLqeQuXty5szfDqFIl2vgylUaulFwpuSqBX37x9smHHuqLumZjd8DiLFrkndD23dfnpUX9zyNTTZ3qc9nuuMM7P0kaWLXKV/Q85xwYODDph3/gAe+6+dJLyZ3oLiLpYfly2HFHH6V+5JGoo9ncjz9C//7w3HNeQrjLLt7OvVMnX8tSEqfkSmWBkqDctutVqvjIjBKrgtWrB//9r18F69s36mgy1xNP+Jw+tV9PIy+/7LPAk1gSGO+f/4TmzVUeKFJR5ZYEpuPFk9zSwLlz4ZVX/ELy/ffDnnvC8cf7gP2aNVFHKZlCI1cauUpIjx5eCqirysULwf8YT5rkc4Z22inqiDLLihWw225ePjJ4cNTRyJ+OPtqznilTym0S3HffQbNm/r0fNqxcXkJEIvLXv/qivzNnZsY82rlzfSSrXz+fT73ttn6RuXNnL2OWgmnkSiNXkoBPP4X77oMOHZRYJcIMeveG1at9LR8pmeee8wEStV9PIz/9BJ995jUy5XhWdNBBXgr68suaeyVSkSxbBiNH+pqFmZBYgV/ku/VWmDYNPvwQTj/dK1IOPdRvTz3l70skP41caeSqSGq7Xnp33ulrbYwcCSefHHU0mWHTJp+zVreud3SSNHHzzfDwwzBnjs+7KkcbN/paNLNne8vkHXYo15cTkRTIbYY1bpwvHp6pli71EsF+/bw6pXp1OPdcH8069ljNswaNXIGSKyVXRQgBLrrI64/HjIEWLaKOKLOsXeuJ6caNXu5Uo0bUEaW/t9/2LoFDh/rPnqSBjRuhQQPvl/7GGyl5yW+/9fLAc87x9a9EJLOdeab/XmdKSWAiJk70kayhQ71ZR+PGnmS1b++LJGcrJVcqC5QiDBrkc6z+/W8lVqVRvbqXB06fDvfeG3U0maFXLx8YOffcqCORP739Nvz2W7k1sihIkyZw++3+9+eVV1L2siJSDpYuhffe82kFFSWxgrzSwF9/9fnBDRt6GWHDhp5MjhjhzcAk+2jkSiNXBZo2zSdsNmvmtcbqDlh67dvDCy94WeWBB0YdTfqaMsU7Nt11lzdQkTTRpo0vHjxnjtcHp8iGDV4eOHeulwfWq5eylxaRJBo40Nuaf/mlD4BXZNOmeUv3gQN9OcCddoJ27fza1L77Rh1damjkSsmVkqsCbNjgq5b//LN39mnQIOqIMtvChT6P6IADYPRo1WQXpnt36NPHz+F33DHqaATwEavddoMbboAHH0z5y0+e7O3Zzz3XL1CISOY54wxfKHz69Io1clWUjRvh3Xe9bPCttyAnB1q2hC5d4PzzoVYFTj2UXKksUArw73/7FaZnn1VilQw77ODrZ3z2GQwYEHU06Wn5cr/Sd9FFSqzSyqBBflbQsWMkL3/wwT6K+eKLMHx4JCGISBnklgSef372JFbga4LmlgbOnevXphYu9D+l9etD165+npXl4xsVlkauNHK1mU8+geOO87br/ftHHU3FEYJ/Xb/91svflEBs7tFHvW39V195KaqkgRB8yHWHHfzKQEQ2bPA5n5Mm+cWeFi28tOiww3xUa5ttIgtNRIoxYICv4DB+vP++ZrMQvDlY376+1MTq1b78ROfOcOmlFaf0WSNXESVXZtYN+D+gPvA98PcQwqeF7DsQaF/AQ5t988ysGnAbcBmwC7AAeDiE0KuoWJRc5Vm61LvbbbWVzw+qXTvqiCqWH3/0r+8FF2hx3Hg5ObDPPn41L8JzeMnvs8984eD+/SMbucq1YIG3Px4/3q/2Tp/u2818HkNuwtWiRd7fMBGJ3mmn+TJ5v/ySXSNXxVmxwkfk+/b1v2vVqvn01i5d4MQTM3v6gJKrCJIrM7sAGAJ0Az6LfewIHBBCmF3A/nWA/E2sxwCfhBA6xu33KrAbcCswFdgJqBFCGFVUPEquXAhw4YXw6qswdmzFn3QalR494J574IMP4IQToo4mPbz5Jvztb94ZTotUp5GOHb0Wb/78tLvSsnixn5DkJlvjx3sCBt5z4y9/yUu2DjvMB+DUlEcktZYs8YYON9wADzwQdTTp69tvfd2swYP9a9awof/57dgRdt896uhKTslVNMnVF8DkEMLlcdumAsNDCLck8PyWeFLWMoQwNrbtZOBlYM8QwqKSxKPkyuV287nvPril2O+ClNaaNT6PBPwPavXq0caTDk46yUslp09PaTM6Kcoff8DOO/skuL59o46mWCH4vIbcROvLL73E9I8//PHatb3cND7h2n13XUkXKU/9+3vJm8q9E7NuHbz+uv/J/eAD33bSSf41bNMmc0bklVylOLmKle6tBi4KIbwct/1J4KAQwrEJHGMg0DyEcFDctqeAfYAvgXbAGuAd4F8hhJVFHU/JlbcObdrU66HVdr38ffCB/8Hs0cPbjmezH37w9vRK6tNM375w+eU+jH3kkVFHUyqbNnk5Uvzo1qRJsH69P77DDpsnW4cd5ttEJDlOPRWmTvVzDF3IKJlZs3y+Wv/+3kG3bl247DJPtA46qPjnR0nJVeqTq12AecCxIYRP4rbfDlwSQihyFYBYieB84JYQQs+47e8CxwEfAncB2wKP4yNk5xVwnK5AV4Bq1ao1W7duXRnfWebasMHbg06bBt98o+6AqXLppTBsmLea3m+/qKOJzlVX+T+QuXMrzmTeCuHII72F4/ffV6izovXr/XcuPuH64Ye8jl2NGm2ebDVrlnYVkSIZYfFiLwn8v/+D+++POprMlZPjF2T79ctblLhFC0+yLrwwPRv6KLnKvOTqauC/wC4hhCVx298DjgZ2DiEsj207GRgZ27agsGNm+8jVrbf6qMHLL8N5W6ShUl5+/92TqiZNYNSoCnX+mrClS30JpQsv9H8ckiZyhxMfftgnS1Rwf/wBEyduXlI4a5Y/VqmSL2wd3zCjSROffC4ihcsd/J44EQ45JOpoKoZFi2DIEP/afv891Kzp85Q7d/aL5OlyHqHkKsPKAs1sEvB9COGSfNufw+dg7RW3rQEwG2gRQhhf2DGzObkaPRpat/a5Vjq5Tb3cfz5p0IwtEg8/7Fc1v/7ay1IlTfzzn9CzJ8ybl7VrBvz+u88TiU+4FsVm8261lf+8xpcU7rNPZnf3Ekm2k0/2ebRTp6bPSX9FEYL/TerXzxdXX7nSu6Z26gTt2/uIYZSUXEXX0OKbEELXuG0/A68U1dDCzFoAXwCt83cAjJX5PQbsmDvHysxOAD4Adgoh/F7YcbM1uVq61Bsr1KjhV5ZU+pJ6mzbBMcd4M4cpU7KrLC4nB/bc05sKjB4ddTTyp/XrfTixVStvHSqAn8zMmrV5sjVhAuT+69hmG5+zGp9w7babTiolOy1a5P1wbrzRK2Ok/Kxc6ZVH/fr5GlrnnAOvvBJtTEquomvFPhhvwT4GuBLoDBwYQphlZoMAQgjt8j2vL3BMCGGfAo5ZG/gRGAfcic+5egb4MYRwflHxZGNyFYKvtfTaa2q7HrXvv/er4Jdc4h0bs8WIEXD22f5P4Jxzoo5G/vTqq3DuufDWW3DGGVFHk9ZycvyiSHzCNXmyz4kAP7nMnbuVm3Btv320MYukQp8+0LWrqhJSbcoU/7t04IHRxqHkKtpFhG/EFxH+DvhH7hwsMxsFEEI4Lm7/rfFGFneFEP5TyDH3xZtYtAKWAiOAm0MIfxQVSzYmV7krpt9/P9x8c9TRSO68t48+8jLNbHD88b6o5C+/QJUqUUcjfzrjDG+pN2uWvjGlsHatNwaKb5gxZUre43vuuXmydeihPm9CpCI56ST/E/LTTxq9zUZKrhJNrsy2IoQK2VIv25KrqVN9culhh3kHGrVdj96aNd5atUoVv/KdKWtZlNbkyb7I64MPetmIpIl583z1yptvhnvvjTqaCmP5ci8hjE+45szxxypX9qvM8R0KDzpI671J5lq40Edtb7kF7rkn6mgkCkquINFLk79i9jzQlxAml2dAUn42bPDys2rVfCVwJVbpoUYNeOopXxPkgQfgjjuijqh8Pf64v+cuXaKORDbz3HM+ETAbu6uUozp1fKT2+OPztv322+bJ1iuv5K3VXL26XwCL71C4114aAZDM8Oqr/mfk/CInZIhUbImOXG0CcnecAPQBXqCYBXozQTaNXP3rX14KOHy4T6uQ9HLxxX6SNXmyd/6piBYv9on+l10Gzz4bdTTyp02bvOXdbrv52gCSUiF4Z7XcZGv8eB/tWrPGH9922y3nb+2yS7QxixTkxBN9ZHbKFF0QyFYauUo8ufoKODRuS8Bbqr8E9COEz8sluhTIluRq1Ci/ctqpU94VUkkvv/3ma18deih8+GHF/Mf04INedfbtt+m/ynxWGTXKJ/wNGuSZr0Ru40Zfciy+Yca33/qEdfDkKn50q3lzT8JEovL771C/vl/IvfvuqKORqCi5KklDC7O9gAuBC4DcXiS5T/4ReBpPtNYmOcZylQ3J1ZIlPsdFbdfT3zPPwJVXeoVWu3bF759JNm6Exo1h7709eZQ0ctll8MYbMH++OiyksdWrvd9I7ujWl1/6PNpc++yz+ehW06b+d18kFXr3hquu8uqLJk2ijkaiouSqtN0CzQ7CO/PlLvqbe5A5wOmE8ENSokuBip5cheAreI8YAZ9/7lc3JX1t2uRLDE2d6mUVdetGHVHyDB/udfgjRkCbNlFHI39avtxnoHfoAE8/HXU0UkJLl/qCx/FzuH791R+rUsVPcuMTrgMOUCNIKR/HH+/XZ374oWJWXkhilFyVNLky2wZoD1wB7J+7FViHN8eoDIwmhIxpKF3Rk6v+/aFzZ2+UcNNNUUcjifj2Wy8NbNfOFwasKI45xmvxp01TM5W0knu5+csvtehdBTFv3uajW+PHew4NXjr4/vu60CbJtWCBl6reeivcdVfU0UiUlFwlPufqMHyx3wuAGnhCBbAAeAovCdwRmAjkkEFf1IqcXOW2XW/RwtuuV6oUdUSSqJtv9vlJo0bBsccWu3va+/prTxgffhhuuCHqaGQzhx0G69b5Ak263FwhbdrkFzXGj4drr4UTToBhw6KOSiqSp5+Gbt00n1aUXEHJuwXm/uf9GuiJdwzcELffz8CehJAx16UranK1fj20bOmLtE6e7E3AJHOsXu3r31Sv7nMsMn3tq06d4KWXYO5c2G67qKORP+UuOvbYY3DddVFHIylw/fW+HMLcubDTTlFHIxVF69Y+evX997pGk+2UXEFJxjIC8DpwHCE0I4RBmyVW7kagU9Kik1K74w6vw+/bV4lVJqpZ09e+mjIFHnoo6mjKZuFCGDoU2rJJPFkAACAASURBVLdXYpV2+vXzhe8uvTTqSCRFunb15jIDBkQdiVQUv/0Go0f7/G4lViKJj1w9CvQihBnlHlGKVcSRq48/9rKPzp2hT5+oo5GyuOACeP11L7XYe++ooymd++7zOvzvv/fJ9JIm1q3zSRInnujDipI1WreG2bO9dFzl4lJWTz4J3bvDd995xYVkN41clbZbYAVS0ZKrJUvg4IOhVi1vu14rq3+8M9/8+b721WGH+ST0TLsquGED7LGHJ1XvvRd1NLKZYcM8e3/3XTjllKijkRR68UW46CIYORJOPjnqaCTTHXssLFrkF9BElFwlWhZo9hBm0zH7Z77t/4xt/095BCclE4KXfPz+u5dhKbHKfPXrw/33+7pQQ4dGHU3Jvfqqdy679tqoI5Et9OsHDRr4yJVklbPPhnr1vFGkSFnMnw+ffuolgSLiEi0IaAPsDryVb/sbQKPY4xKx/v3hlVfgnnugWbOoo5FkueIKOPxw+Mc/fGQyk/TqBXvuCaefHnUksplZs3wotGNH9cXPQltt5d/6N97IWxNLpDReecUv7J5/ftSRiKSPRJOr3JYIM/Ntnx372CAp0Uip/fyzjw4cfzz885/F7y+Zo3JleOYZT6wyaa2yr76CsWPhmms0ryPtPPecnxF17Bh1JBKRrl0hJ8cvyomU1rBh3npd82lF8iR6yrMx9rFJvu1N8j0uEVi/Hi6+2Nt2DxqkE9mK6C9/8ZGrvn3hs8+ijiYxjz8OtWtDhw5RRyKb2bTJW8WdcAI0ahR1NBKRvfbyH4E+fTzJEimpefP8/5FGrUQ2l+hp+E+xj/0xa4VZXcxaAX1j26ckPzRJ1O23w4QJfuK9665RRyPl5c47oWFDLxNcvz7qaIq2YIFPmu/QAerUiToa2cxHH8HMmd5OVLLaFVd418CRI6OORDKRSgJFCpZocvUivoDwAcBo4PfYxyb4+lcvlkt0UqyPP4b//Acuv9wnKUvFVauWt7z94Qd4+OGooynaM894Ati9e9SRyBb69fMFx/QHI+u1aQM77ui/ryIl9fLL0KQJ7L9/1JGIpJdEk6tewFg8wYq/AYyJPS4ptngxXHYZ7LMPPPpo1NFIKpx5Jpx7Ltx9N/zyS9TRFGz9enj6aTj1VNh336ijkc0sWQKvvQaXXOJ1xJLVqlWDTp3grbdg7tyoo5FMklsSqC6BIltKLLkKYQNwAnAznkxNi328CTiJEDTnKsXUdj179ewJVatCt27+c5Buhg+H335T+/W0NHSoLx6skkCJufxyn4bXr1/UkUgmGT7cP6okUGRLWkQ4QxcR7tvX/yn+5z/wf/8XdTSSak884V34hg71xUDTyRFHwNKl8OOPaq6Sdg45xFeinjgx6kgkjZx6qi8AO2MGVKkSdTSSCVq2hJUr4Ztvoo5E0o0WEU68LNCZbYvZYZgds8VNUuann+C667zT0w03RB2NROGqq6B5c+8guHRp1NHk+eILv6n9ehqaOBEmTdKolWzhiiu8LPCdd6KORDLB3Lm+zIZKAkUKltjpj1lVzPoBC4FxwMf5bh+VV4Cyufi26889pxPYbFW5Mjz7LCxcCLfcEnU0eXr1gq23hvbto45EttCvn68ee/HFUUciaebMM6F+fTW2kMSoJFCkaImemv8T6AhUZsumFvHNLaSc3XabX4Du109t17PdIYfA3//uJ0Rjx0YdDfz6qy8o2amTJ1iSRtas8RrSc8/1ToEicapW9QHNt9+GWbOijkbS3bBh0LSpN9MSkS0lmlxdiLdcnxT7PACvAmvx5hbPJT80ye/DD+Ghh7yRxVlnRR2NpIN//xsaNPCyng0boo3lmWd8MVK1X09Dr70Gy5Z55itSgC5d/GPfvkXvJ9lt9mz4/HOVBIoUJdHkas/Yx/P+3BLCecD5wB7Am8kNS/JbvBjatfPW1o88EnU0ki5q1/bmFt99F+3Pxbp10Ls3nHEG7LVXdHFIIfr1gz32gNato45E0tTuu8Npp/mPStQXaiR9qSRQpHiJJldVYx9nATkAmNUAPsBLBf+d9MjkTyH4VcWFC+GFF9R2XTb3t7/5erD//rd3+4rCsGG+LIDar6eh6dPho4+gY0dN0pQiXXEFzJ/v616JFOTll70kXRfRRAqX6H/a3H5kNYAlsfs9gNxedfo1K0d9+sCIEXDfff5HTSS/Xr28yUUUa1+F4Gtv7b8/nHhial9bEjBwoLdf79Ah6kgkzZ1+us/lVWMLKcisWTBunEoCpeIyw8zYuazHSTS5mh77uCswEW9gcRNwNz7/KqLr5RXflCnetODEE+H666OORtLVbrvBPffAu+/6lcVU+vxzmDDB26+bWtukl5wcGDAATjnFJ+eJFKFKFa+SeO+96EbBJX2pJFCSycy6mdkMM1trZhPM7Ohi9r/YzCaZ2Woz+83MhpjZznGPX25mn5rZUjNbZmYfm1mrksQUAoEkdEBPNLl6H/gZ2A94GNjE5l0C7yprILKldeu8a3LNmmq7LsXr3h2aNfM10JYvT93r9uoFderAZZel7jUlQe+/74vSqJGFJKhLF79I0qdP1JFIuhk2zP/H7Lln8fuKFMXMLgB6AvcBhwBjgXfMrGEh+7cEBuMN9A4EzgIOAJ6P2+044CXgeOBw4CdgpJntXcLwpplRpp7HiZ2uh3AHIexPCK8TwofAMfgX5b/AMYTwUlmCkILddht8/bVPMN7l/9m77zip6uv/468jTUBEilJEgyUqRZSADRQrhkiwgAiiohBhFWM0iSbxpybGGPNNNMYSE0RBhIiyIDaCASWiIAICIggoqIAVEAsqvZzfH5/ZMCxbZndn5k55Px+Peaxz586ds9dhZ879nM/5NI86Gsl01aqFcp61a+H//b/0vObHH4ermVdeGZprSIYZPhwaNQoT80QS0KJFaEwzYoQaW8guK1fCnDkatZKk+QUw0t0fdvel7n4t8BlwdSn7nwR87O5/c/cV7j4LeICQRAHg7pe4+9/d/U13fzd2rG+BbhWMbT3wvBntKvpLFale7h5mtYB/Esr/7sT9fdxnErLMrNewYUOmTZsWdRh7mDevAXfffQw9enxK/frLyMAQJUNdcMHh/POfB9KmzXxat/42pa81fPgh7Nx5MB06zGbatM0pfS2poO3b4aST4LzzQu2mSII6dWrI88+34847F3PqqZ9HHY5kgLFjDwIO46CDZulvvZSnupnNjbs/zN2HFd0xs5pAB0IlXLwpQKdSjvkacKeZ9QAmAo0Iy0RNKiOOmsDe7OobkagPgAbAZDOqAW8Ab7hzW6IHME9k9rvZRqAWsA/umyoYZEarW7eub9iwIeowdrNuHbRrF0qt5s0LZYEiifr229BcolEjmDs3LBCaCps3h2k8nTuHhiuSYe69F37+c1i0CNq2jToaySI7dsChh4ZFYl98MepoJBMcf3xoXvTGG1FHIpnOzDa6e6l9rc2sOfAJcKq7vxq3/bfAJe5+ZCnP6wmMJDTXq06YsnSel5KXmNldwMVAa3f/pvy4aeTOF8W2HUhIBDu487vyjlEk0Vk8RYsH75/ogctSkUlsZjbSzLyE24a4fU4rZZ+jkhFvOhW1XV+3DsaMUWIlFVevHjzwACxcGLr4pcoTT4T3qdqvZyD3UBJ4/PFKrKTCqlWDQYPgpZfgvfeijkaitmJFSKrUJVCiYmatCWWAfyAkO92ApkCJvU3N7DqgAOiZSGIVs8yMD8wYa8YvzegCrHfnuYokVpB4cvUrYAswFLMmFXmB4io6iQ24DmhW7PYBUFjCvm2K7be8KrFGYdgwePZZ+NOf1HZdKu/888M0m9/9LrTPTTb30MiiTRutS5uR3ngjrCytRhZSSQMHhiRr2LDy95XcVtSBVvOtJEnWEdbMLZ5PNAFWl/Kcm4A57n6Xuy9098nAEOAyM2sRv6OZXQ/cAZzj7nMSDcqdRsAPgbeAW4BhwOdmLDbj0USPA4knV6MIJ+KHwKeYfYbZB3G39yvwmhWaxObu6919ddENOAw4FCipl9Ha+H3dfUcF4orc0qWhiqdr1/BTpLLMwuiVGVxzTfLXvpoxAxYsCKNWar+egYYPh9q1oW/fqCORLNW8ebhA8+ijoXOt5K/CQjjuOGjZMupIJBe4+1ZgHtC12ENdKb2fQx1CHhKv6P7/chkz+wVhdKu7u8+oeGwsJ4yKfd+do4DvAYuBfStynESTq5aEXwxC+/UmsW3xt3LFTWKbUuyhsiaxFTcIWOyhqUZxc83sMzObamalXk83s8FmNtfM5m7fvj3Bl02t+LbrI0eq7bpU3cEHw+23w7//DRMmJPfY998PDRrApZcm97iSBBs3hprN3r3DxE2RSiooCKW/Tz8ddSQSlQ8+CHO/VRIoSXYPcIWZXWlmrczsPqA5MBTAzEaZ2ai4/Z8HzjOzq83s0Fhr9vuB+e7+Yew5NwL/B/wEWGZmTWO3in4QNnRnHYA7a4FL2HOUrUyJfoX/MO62qoTbhwkepzFQDVhTbPsaKH9F5NgJuog9R62KRr56AT0Jve2nljaXy92HuXtHd+9YvXr5DRPT4eabw0jAiBFquy7J87OfwbHHhp/fJFp1XI4PPwxftgYN0pzAjDR+fOhq8pOfRB2JZLmuXeGQQ8ISD5KfVBIoqeBhCafrCeV3C4CTCWV8RRMZDo7divYfSah8+ynwNjCesP7ueXGHvQaoQVjr6rO4W0Vnn881I342+U7ggIocILFugUlS2Q4hcftdQ1hbq7m7f1nOvpOA7e5e5gIvmdAt8MUX4eyz4aqr4J//jDQUyUFvvAEnnBAWGb7//qof7ze/gbvuClc0v/e9qh9PkuzUU+HTT2HZMtVsSpX96U9h3bx33oEjy/yEllzUoUPoODtrVtSRSLYor1tgpjKjszuvmVGfkLw1BuYA7YC17rslcmVKd/FZZSaxxRsEPFVeYhUzG6joqsxpt24dXH55aJ39179GHY3kouOOC/Ou/v73qrfR3bgRHn44NMxQYpWBli+HV18N3QiUWEkSDBgA1aursUU+eu89mD9fo1aSN4pGuK50pyuhod67wD8IVXMJS6wmzqx/ufu4jyp/F99qZkWT2MbFPdQVeKrsEOx44BjCMGIijiUMB2a0qVPh669h0iSVWEnq3HFHmHc1eHBIsCpbDTtmDHz5pdqvZ6wRI8KEzcsvjzoSyRFNm4aLKSNHwh//CHvvHXVEki5FJYEXXhhtHCJpUsOMQwlzrP7qzqvAq+U8p0SJLiK8EyhrR8c9oa9rsVbsowktFF8DriJMPmvj7quKJrC5e/9iz3sE6OLuR5RwzOuBlYSOHjWBS4HfAL3cvcyp/JlQFrhmDTSpUoN7kfI99VT4kLznnsp1o3SHY44J393ffFMDIxln+/bQxaRDB3j++aijkRzy0kth/tW//gWXXBJ1NJIuP/gB1KoFr78edSSSTbK4LPAi4G9AfUKjvbmx27ziiwuXpyJlgVbOLSEVncQGYGb1gL7AI6UctiZwF7AQmB47ZvfyEqtMocRK0qFnT+jeHW69NTSlqKhXXoFFi9R+PWP95z/w2WdqZCFJd8YZcPjhamyRT5YvDxfR1CVQcpnZrgo+dwqBFsDHwONAPeAG4F0zVlTouAmOXBWvMalOWGvqJ0Bd4Fe4Z2UrhkwYuRJJl5Urw8K/Z50VFquuiAsugOnT4aOPwhJKkmEuuABmzoSPPw4z0EWS6K674Fe/CmtTt2kTdTSSanfeGboYf/ghHHRQ1NFINsmmkSszlgDXuPNy3Lb93Pm62H6HuCeeYCU2cuX+WLHbcNxvBk4hrH91SKIvKCLRadkSfv97eO45eOaZxJ+3YkV4zuDBSqwy0po1MHEi9O+vxEpS4ooroGZNNbbIF4WFcNJJSqwk5y0CXjLjCTOaAxRPrGLbKjRyVdVuge8BGwmTv0QkC1x3HbRrF1qzf/ttYs/5xz9CKeDVV6c2Nqmk0aPDnCuVBEqK7L9/KC0eNQo2bYo6GkmlZcvgrbdUEii5z50+wNmEhnlLzfiFGdWqetzEkiuz/iXcBgPPEMoC96lqICKSHjVqhLkTn34a5l+VZ8MGeOSR8MVKVzEzkDsMHw6dOsFRR0UdjeSwgoLQ3bawMOpIJJXUJVDyiTtTCWtZ3Qn8HlhgRpeqHDNZ3QL/i3vXqgQSFc25knx1zTUwdCjMmRMazJXmoYfCAtczZkDnzumLTxI0c2b4H/PIIxq5kpRyD2syNmwY3naSm445BurVC3/zRSoqm+ZcFWfGgcC9QE/gCeCX7qyp6HGS0S3wfeCair6wiETrzjvhgAPCPKrt20vexx3uvz+05O3UKb3xSYKGD4e6dVXDIylnFv5evP566Bwqueedd2DhQv05kfxjRgPge8B/gHlAP+ADM2aYcZ8Z5a/5G5NocjWghFs/oDPQCvdlFYhfRDJA/fpw330wfz48+GDJ+0ydCkuWqP16xvr2Wxg7Fvr0CZeaRVLs8svD2kdqy56bikoCe/WKNg6RdDDjR2a8ZMZqYB0wAxgK7As8C/yD0Jr9HGBEwsdNqCwwh6ksUPKZe1j7avp0WLoUWrTY/fFzz4VZs0I73r33jiZGKcOIEaEU8LXXNLQoaXPppWGd6k8/DYOmkjvatQsX3qZPjzoSyVbZVBYYS6q+IqxrtQR4B1juzrYS9t3XnW8SOW6iDS0OwawLZq2KbW8V265W7CJZyCyMWu3YEUan4r3/fujuXVCgxCpjDR8emlicdFLUkUgeKSiAb74Jg6aSO5YuDeWeKgmUPDId6O/OHe5McGdJSYkVQKKJFSReFvgg8DJwfLHtHWPb/57oC4pIZjnkEPjd7+Dpp8NaVkUefBCqVVP79Yy1dGnoKjBwoGo2Ja1OPhlat1ZpYK4ZNy78KVFJoOQLd3q780ayj5tot8DVwP5AM9zXxm3fH1gDrMG9WbKDSweVBYrAtm2hacX69WGOFcCBB4aSwTFjoo1NSnHjjXDvvfDxx9CkSdTRSJ65//6wZt78+dC+fdTRSDK0bQuNGsErr0QdiWSzbCoLTJVER64axH5uLrZ9a+xnw+SEIyJRKFr76qOPwijWY4+Fsp/ipYKSIbZtC6u5/vjHSqwkEpddFsqFNXqVG5YsgcWLoXfvqCMRyX6JJldfxX4W/2fXq9jjIpKlOnUKcynuvTe0aT/uODjhhKijkhL9+9+wdq3WtZLINGgQmlQ+/nhoWinZTSWBIsmTaHI1i7Cm1T8wG47ZLzF7BPgnYXHhWakKUETS509/gv33D13A1H49gw0fDs2aQbduUUcieaygAL77Dp54IupIpKoKC6FLl/BnRUSqJtHk6j5CElUduAL4C2Gtqxqx7X9LRXAikl4NGoTv7d27qzwkY336KUyaFBYcql496mgkj514Ihx9tEoDs93ixaEsUF0CRZIjseTK/WXgemAbYQSr6LYV+Dnumv4okiO6dw8t2GvVijoSKdFjj8HOnaFLoEiEzMLo1fz5MHdu1NFIZRUWwl57Qc+eUUcikhsqtoiw2YFAN6AJoUvgf3D/JDWhpYe6BYpI1nCHI46A5s3V0ksywvr14e3Yrx88/HDU0UhFuYe2+k2bwssvRx2N5AJ1C0y8LDBw/wT34bjfGfuZ1YmViEhWmT4d3ntPjSwkY9SvD337hnlX3yS8xKZkisWL4Z13VBIokkyJJVdmN2L2X8yuLrb96tj2X6YiOBERiTN8ONSrp5ZeklEKCmDDhtA5ULKLSgJFki/RRYTfBloBHXF/M257O2ABsAT3timKMaVUFigiWWH9+tDK67LL1EFAMop7WITcHd58U11Gs4U7tGoVFoyfOjXqaCRXqCww8bLAlrGfS4ttXxb7+b2kRCMiIiUbOxY2bVJJoGQcM7jqKnjrLZg9O+poJFGLFsG776ozrEiyJZpcFV2HOqTY9kMreBwREamM4cOhbduwurNIhunXD/bZR4Oq2UQlgSKpkWhS9H7s5z8xawEQ+/lgscdFRCTZ3n4b5swJo1aquZIMVK9eSLDGjoWvv446GimPO4wbB6efDgccEHU0Irkl0eTqGcLo1SnAKsy+BVYBXQiLCE9ITXgiIsLw4VCjBlx6adSRiJSqoCBUro4eHXUkUp6FC2HZMnUJFEmFRBta7APMBY4o4dF3geNw/y65oaWHGlqISEbbsiXMOD/99HCpWSSDHXdcSLAWLdIgaya7+Wb485/hs89g//2jjkZyiRpaJDpyFRKnzsBQ4BNge+znP2LbG6coPhGR/Pb88/DFF2pkIVmhoCCsnTRzZtSRSGncw3yr009XYiWSCok3onD/AvchuB+Ee02gHfA28CzwXoriExHJb8OHQ4sW0LVr1JGIlKtv3zD/So0tMteCBWEtcpUEiqRGxbr8mdXArCdmE4BPCQ0tOrOrm6CIiCTLRx/B5MlwxRVQrVrU0YiUa599wtTAwkL48suoo5GSjBsX/pxccEHUkYjkpsSSK7NTMHsIWA2MA84DarErqfokJdGJiOSzkSNDDc+AAVFHIpKwgoIwVXDUqKgjkeKKSgLPPBMaa0KHSEqU3tDC7EjgMqAfuxYJLj5C5cAPgakk1Bkj86ihhYhkpJ074fDD4ZBDYOrUqKMRqZATT4T162HJEjW2yCTz50OHDvDII5rGKamhhhZlj1wtBW4CWhKSKgO+BkYDN/xvL/eXsjWxEhHJWNOmwYoV+gYkWemqq+Cdd+DVV6OOROIVFoaSwPPPjzoSkdyVSFmgA08A3YADcL8cmJzSqERE8t3w4bDffpoYIVnpoougfn01tsgkRSWBZ50FjRpFHY1I7kq0ocV5wGCgV2zNqyoxsyFmtsLMNpvZPDM7pYx9R5qZl3ArsZbPzE42s+1m9nZV4xQRicRXX8FTT0G/flC7dtTRiFRYnTrQv394G69bF3U0AqEkcMUKdQkUSbWykqtZ7CoHrANcAIwB1gKVvhZlZn2A+4A7gfbATOAFMzu4lKdcBzQrdvsAKCzh2A2AUYAmKIhI9hozJnQEUEmgZLGCAti6NfRlkegVFkL16ioJFEm10htaAJgdyq6mFt+Pe8QJSZcDY4HRuL+Q0AuazQYWuvuguG3LgfHuflMCz+8MzAA6u/vMYo9NAN6KxXahu7ct73hqaCEiGadDh9DQ4s03o45EpEpOPhnWroV331Vjiyi5w6GHQqtWMGlS1NFILlNDi/LKAt0/wP33uB8JnERY12odu3cN7AM8n8iLmVlNoAMwpdhDU4BOCcY8CFhcQmI1BGgC3JHgcUREMs+CBaF+R6NWkgMKCmD5cnj55agjyW9z58LKldC7d9SRiOS+xBcRdp+N+7VAc+BcQlneZnaVDiaiMVANWFNs+xqgaXlPNrP6wEXAw8W2Hw38DrjU3XckcJzBZjbXzOZu3749wdBFRNJg+HCoVSvMtxLJchdeCA0aqLFF1AoLoUYNlQSKpEPiyVUR9+24T8S9LyEhuhKYluS4SnMpIebRRRvMrBahNPEGd1+RyEHcfZi7d3T3jtWrV09NpCIiFbV5Mzz+eOgQ2LBh1NGIVFnt2nD55fD006E8UNLPHcaNg65dQ6IrIqlV8eQqnvu3uI/A/cwEn7EO2EEo34vXBFidwPMHAU+5+5dx25oBrYBHY10CtwO/BdrE7p+dYGwiItF65pnQKVAlgZJDBg+Gbdvg0UejjiQ/vfEGrFqlLoEi6VK15KqC3H0rMA/oWuyhroSugaUys+OBYyhWEgh8AhwNHBt3Gwq8F/vvMo8rIpIxhg+Hli3hjDOijkQkaVq1gi5dYNiw0KdF0quoJPC886KORCQ/pDW5irkHuMLMrjSzVmZ2H2Ee11AAMxtlZqNKeN5gYLm7T4vf6O7b3P3t+BuhXfyW2P3vUvvriIgkwcqV8NJLMGAA7BXFn2aR1CkogA8+gKlaKCWtikoCzz47rEkuIqmX9k9wdx8LXA/cAiwATgbOcfdVsV0Ojt3+x8zqAX2BR9IYqohI+jz6aOhVfcUVUUciknS9ekHjxjB0aNSR5Jc5c+DDD1USKJJOZa9zlQe0zpWIRG7HDjjkkFA/NXly1NGIpMSNN8Lf/gYffQTNmkUdTX745S/h73+HNWs0ciXpoXWuoikLFBGReFOnhm+camQhOWzw4HAdYcSIqCPJDzt3hpLAH/5QiZVIOim5EhGJ2vDhofW6ZpxLDvv+90OvlocfDkmWpNbs2eGajRYOFkkvJVciIlH64ovQgv3SS8PiwSI5rKAgtAWfMiXqSHJfYSHUrAnnnht1JCL5RcmViEiU/vUv2LpVJYGSF84/Hw44AB56KOpIctvOnTB+PHTrBvXrRx2NSH5RciUiEhX3UBLYsSO0axd1NCIpV7NmWG1g4kT45JOoo8lds2bBxx+rS6BIFJRciYhEZd48WLRIo1aSVwYNCnOuhg+POpLcVVgYqox79Ig6EpH8o+RKRCQqw4fD3nvDxRdHHYlI2hx2GHTtCo88osYWqVDUJbBbN9h336ijEck/Sq5ERKKwcSOMGQMXXqhJEZJ3CgpCJ7sXXog6ktwzcyZ8+qlKAiWzmdkQM1thZpvNbJ6ZnVLO/v3MbIGZbTSz1Wb2LzNrGvd4GzMbb2YfmJmb2W0p/yVKoeRKRCQKEybAN9+oJFDy0rnnQtOmMHRo1JHknnHjVBIomc3M+gD3AXcC7YGZwAtmdnAp+3cGRgOPAW2A84HWwONxu9UBVgK3ACtSFXsilFyJiERh+PBQH3XqqVFHIpJ2NWqE6wovvAAffhh1NLmjqCTwnHOgXr2ooxEp1S+Ake7+sLsvdfdrgc+Aq0vZ/yTgY3f/m7uvcPdZwAPACUU7uPsb7n6Du48BNqb6FyhL9ShfPBM0bNiQadOmRR2GiOSTLVvgxz+GAw+EV16JOhqRSLRtWwv3E7nlllUMHLgy6nBywsKF9fnss/a0bbuEadPWRh2O5KfqZjY37v4wdx9WdMfMagIdgLuLPW8K0KmUhoGWogAAIABJREFUY74G3GlmPYCJQCOgLzApaVEnkbl71DFEqm7dur5hw4aowxCRfHLzzfB//xcu2R94YNTRiETmnHPgrbfCwsLV8/5yb9Vde21oFPL557DPPlFHI/nIzDa6e90yHm8OfAKc6u6vxm3/LXCJux9ZyvN6AiOB2oTBoReB89x9Uwn7vg2Md/fbqvCrVJrKAkVE0mn7dhg5MrTyUmIlea6gIDRfmDgx6kiy344dYeHgc85RYiW5xcxaE8oA/0AY9eoGNAUycjlyJVciIuk0ZUr4NqlGFiJ07x6uMTyUkV+Rsstrr8Hq1eoSKBlvHbADaFJsexNgdSnPuQmY4+53uftCd58MDAEuM7MWqQu1cpRciYik0/DhsP/+Yc6VSJ6rXj1cZ5g8GVaujDqa7FZYCLVrh4RVJFO5+1ZgHtC12ENdCV0DS1KHkJDFK7qfcblMxgUkIpKz1q6F556D/v2hZs2ooxHJCFdeCWbw8MNRR5K9ikoCu3dXSaBkhXuAK8zsSjNrZWb3Ac2BoQBmNsrMRsXt/zxwnpldbWaHxlqz3w/Md/cPY8+paWbHmtmxwN5A09j9w9P6m6FugSIi6TN6dJhzNXBg1JGIZIyDDgrzhEaMgNtuC23apWKmT4c1a6B376gjESmfu481s0aENamaAW8D57j7qtguBxfbf6SZ1QN+CvwVWA/8F/h13G7NgTfj7h8GFACvAKel4NcolboFqlugiKSDO7RtC/vuC6+/HnU0Ihll4sSw6O348dCrV9TRZJ8hQ0KfnM8/h7ql9mkTSb3yugXmA5UFioikw+zZsGSJGlmIlOBHPwojWEOHRh1J9tmxA556KkzjVGIlEj0lVyIi6TB8ePjm06dP1JGIZJxq1WDQIHjpJXjvvaijyS6vvhqmc6pLoEhmUHIlIpJq330HTz4Zvv3Uqxd1NCIZ6Sc/CUmWGltUTGEh1KkT5q2JSPSUXImIpNq4cSHBUiMLkVI1bx7mXT36KGzdGnU02WH79l0lgXXqRB2NiICSKxGR1BsxAo48Ejp3jjoSkYxWUBCaMjz9dNSRZIdXXgnnSyWBIplDyZWISCq9+y7MmBFGrcyijkYko519NrRsCQ89FHUk2WHcuDCV80c/ijoSESmi5EpEJJVGjAgTSfr3jzoSkYy3116hscXLL8OyZVFHk9mKSgJ79FBJoEgmUXIlIpIq27bBY49B9+7QtGnU0YhkhYEDoXp1GDYs6kgy27RpsG6dFg4WyTRKrkREUuWFF2DNGq1tJVIBTZvCeeeFRXE3b446msxVWKiSQJFMpORKRCQVtmwJE0eaNlWPZJEKKiiAL76ACROijiQzbd8ezs2550Lt2lFHIyLxqkcdgIhI1vvuO3jrLZg/H958M9wWLw5lgTffHGqcRCRhZ54Jhx4KQ4dCv35RR5N5Xn45JJ/qEiiSefSJLyJSEV98sSuBKkqmli0D9/D4/vvDD34A3bpBhw5w/vnRxiuShfbaK4xe/frXsGQJtG4ddUSZpbAQ9tkn/JkRkcxiXvSFIE/VrVvXN2zYEHUYIpJp3OHTT3cfjZo/Hz78cNc+Bx8M7duHZKroZ/PmarkukgRr10KLFjBkCNx7b9TRZI5t20K1cbdu8PjjUUcjsjsz2+judaOOI0pKrpRcicjOnfDBB7uPRs2fH1bnhJAsHXHE7olU+/bQqFG0cYvkuL59YfLkcJ1Dc4uCyZNDYvXMM6Hxh0gmUXIVUVmgmQ0BbgSaAYuB6919ein7jgQuL+Gh//3PM7NTgT8BRwJ1gFXAI+5+d/KjF5Gstn07LF26eyK1YAF88014vHp1aNsWfvzjXcnUMceEGhwRSauCAhg7NiyWq6XignHjoF49+OEPo45EREqS9pErM+sD/AsYAsyI/RwAtHb3D0vYvz5Q/HrVa8Cr7j4gtk8H4PvAImAj0Bl4CLjR3f9RVjwauRLJYZs3w6JFu49GLVq0q79z7dohcYov62vTBmrVijZuEQFCde5RR0HjxvDaa1FHE71t26BJk7B03ujRUUcjsieNXEWTXM0GFrr7oLhty4Hx7n5TAs/vTEjKOrv7zDL2mwBscfeLyzqekiuRHPHNN2EEKn6O1JIlsGNHeHy//fYs6zvySKhWLdq4RaRMf/0r3HBDuC7Stm3U0UTrP/8J61o99xz06BF1NCJ7UnKV5rJAM6sJdACKl+tNAToleJhBwOJyEqv2sePdVsrjg4HBADVr1kzwZUUkY6xdu2fHvvfe2/V406YhiTr33F3JVMuWajQhkoUuvxz+3/8Ly8Y98EDU0USrsBD23RfOPjvqSESkNGkduTKz5sAnwKnu/mrc9t8Cl7j7keU8vz7wGXCTu99XwuMfA/sTksbfu/vt5cWkkSuRDOYOH320e1nfm2/CJ5/s2ueQQ3YfjWrfHpo1iy5mEUm6Sy6Bf/87NLaoUyfqaKKxdWsoCezRA0aNijoakZJp5Cr71rm6FNgLKK3S+BRgH+BE4M9mtsLdVZUskg127oTly/fs2Pfll+HxvfYKky9OO21XMnXssdCgQaRhi0jqFRTAmDGhucWAAVFHE42pU+Hrr7VwsEimS/fIVU1Cw4mL3X1c3PYHgbbufmo5z19AKAm8JIHXugUY4O6HlbWfRq5EIrB1a5gPVbxjX9G/xZo14eijd58j1a5d/l6yFslz7qHXTL16MHt21NFEY8AAePppWLNGPXckc2nkKs0jV+6+1czmAV2BcXEPdQWeKuu5ZnY8cAxwfYIvtxegPz8iUdu4ERYu3H006u23Q4IFULduSJ4GDtyVTLVqFRIsERHCdMnBg+HnPw/XYY49NuqI0mvr1pBYnX++EiuRTBdFWeA9wGgzm0NoqX4V0BwYCmBmowDcvfiKFoOB5e4+rfgBzexaYAXwbmxTF+AGoMw27CKSZF99tWfHvnfeCSV/EBbdbd8err9+VyJ1+OGh5E9EpAz9+8NNN4XGFv/8Z9TRpNeLL8L69dC7d9SRiEh50p5cuftYM2sE3EJYRPht4Bx3XxXb5eDizzGzekBfoLQGFdWAPwMtge3A+8BviCVsIpICn322Z8e+FSt2Pd6iRUigevfe1WjioIPUsU9EKqVhwzDf6PHH4a678mtd78JCqF8funaNOhIRKU/a17nKNJpzJVIOd1i5cs+OfatX79rn8MN3X4i3fXvYf//IQhaR3DRzJnTuDMOGwaBB5e+fC7ZsCV0CL7gAHn006mhEyqY5V0qulFyJFPftt2GFyvjSvq+/Do9VqwatW+/e+vzYY8PCKyIiKeYeetvUqgVz50YdTXpMnBjar0+aFBYQFslkSq6yrxW7iKTS00/DtdeGdaT23jt8i+nTZ1cydfTRYbuISATMQlv2a6+FefOgQ4eoI0q9wsKw4sSZZ0YdiYgkQiNXGrkSCQv1XnstPPssHHMM3H8/dOoE1XX9RUQyy9dfQ/PmcOmloTwwl23eHEoCe/WCESOijkakfBq5Cu3KRSRf7dgREqnWrWHKFPjLX+CNN6BLFyVWIpKR9tsP+vYNiwp/803U0aTWlCnhd9TCwSLZQ8mVSL5asABOOgmuuw5OPhkWL4Ybb4QaNaKOTESkTAUFYc3xMWOijiS1xo1TSaBItlFyJZJvNmwISVTHjrBqFTzxRJgpfcghUUcmIpKQ448PFcxDh4YmF7lo8+ZQqd2zp655iWQTJVci+WTSJGjTBu6+GwYODAv89u2rtadEJKsUNbZ46y2YMyfqaFJj8uTQvFULB4tkFyVXIvlg9erQ9a97d6hTB6ZPDzPBGzSIOjIRkUq55BKoWxceeijqSFKjsDAsnHzGGVFHIiIVoeRKJJft3Bm+eRx1VKgvuf32sG7VySdHHZmISJXsuy/06wdPPrlrKb5csWlTWG5QJYEi2UfJlUiuWrw4dP276qqwTtXChXDrrWH1TRGRHFBQEBKRf/0r6kiSa/Jk+O47dQkUyUZKrkRyzaZNcMstYdHfd96BkSNh6lQ44oioIxMRSaoOHcLtoYdyq7FFYSE0agSnnx51JCJSUUquRHLJ1KnQrh388Y9w8cUhubr8cjWsEJGcVVAAb78Nr78edSTJEV8SqOUGRbKPkiuRXLBuXUiizjor3H/pJXjsMWjcONq4RERS7OKLoV693Gls8cILYcUMlQSKZCclVyLZzD2U/R11VFhN8+abw9wqrTgpInlin31C58DCQvjqq6ijqbrCwnBd7LTToo5ERCpDyZVItlq2LCRRAwbAkUfCggVwxx1Qu3bUkYmIpFVBQVh0d9SoqCOpmo0bYeJE6NVLJYEi2UrJlUi22boV/vCHMLdq/nwYOjSsW9WmTdSRiYhE4thj4fjjs7+xhUoCRbKfkiuRbDJjRvgW8dvfwnnnwdKl4ZLtXvqnLCL5raAg/EmcPj3qSCqvsBD23z+soiEi2UnfyESywVdfweDBcMopoW7k3/+GsWOhWbOoIxMRyQh9+oSFhbO1sYVKAkVyg5IrkUzmDk8+Ca1awYgRcMMNYXHgc86JOjIRkYxSty707w/jx4cGqtlm0qSQYKkkUCS7KbkSyVQrVoQk6uKL4aCDYO5cuOuu8A1CRET2UFAQpqU+9ljUkVRcYSEccIBKAkWynZIrkUyzbRv85S+hQcWMGXDffTBrVphrJSIipWrbFjp1gmHDsquxxYYNoSTwwguhWrWooxGRqlByJZJJ5syBjh3h17+Gs8+GJUvgZz/Tp62ISIIKCsJKFdOmRR1J4v79b9i0CXr3jjoSEakqJVcimeCbb+Daa+HEE+GLL2DCBHjmmVAOKCIiCevdGxo0yK7GFoWF0KRJ6FkkItlNyZVI1J5+Glq3hgcfhGuuCaNVF1wQdVQiIlmpdu3Q2GLCBFi7Nupoyvfdd6GZhUoCRXKDkiuRqHz0EZx/PvTsCY0aweuvwwMPhF7CIiJSaQUFYfrqyJFRR1K+opJAdQkUyQ1KrkTSbccOuP/+MFo1ZQr8+c+hE+AJJ0QdmYhITmjVKpTYDRsGO3dGHU3ZCgvDkoWdO0cdiYgkg5IrkXRasABOOgmuuw5OPjmsWfWrX0GNGlFHJiKSUwoK4P33YerUqCMp3bffhpLAXr1UEiiSK5RciaTDhg1w442hE+CqVfDEE+ET9ZBDoo5MRCQn9eoVKq4zubHFxImwebNKAkVyiZIrkVSbNCmsWXX33TBwILzzDvTtC2ZRRyYikrP23huuuAKefRZWr446mpKNG6eSQJFco+RKJFVWr4Y+faB7d6hTB159NUwAaNAg6shERPLC4MGwfTuMGBF1JHsqKgns3Rv20rcxyTNmNsTMVpjZZjObZ2ZlLkRgZv3MbIGZbTSz1Wb2LzNrWmyfXma2xMy2xH5G0npZ/5xFkm3nzlCHctRR4ZLp7bfDm29qARMRkTQ74gg4/XR4+OHMa2zx/POwZYsWDpb8Y2Z9gPuAO4H2wEzgBTM7uJT9OwOjgceANsD5QGvg8bh9TgLGxrYdG/s5zszS3i0skuSqItmqmY00My/htiFun55mNsXMPjezb81stpmdm57fRiTO4sXQpQtcdRX84AewcCHceivUqhV1ZCIieamgAFauDM1ZM0lhITRvDp06RR2JSNr9Ahjp7g+7+1J3vxb4DLi6lP1PAj5297+5+wp3nwU8AMQnTtcDL7v7H2PH/CMwLbY9rdKeXFU0WwWuA5oVu30AFMbtcyrwX6B77JiTgKfLG2IUSZpNm+CWW6B9e1i6FB59NLSoOuKIqCMTEclrF1wA+++fWY0tvvkG/vMflQRK/jGzmkAHoPjljilAaZcaXgOamVkPCxoDfQnf94ucVMIxJ5dxzJSpnu4XJC5bjd2/1sy6EbLVm4rv7O7rgfVF92NDg4cCl8Xtc12xp/3ezLoThg2nlxVMw4YNmTZtWiV+DZGYb78NHQAbNAhzqlq0gOrV4ZVXoo5MRESAM888lMLCgxg//nUaN94adTi8+OIBbNnSmsMPn8+0ad9EHY5IMlU3s7lx94e5+7C4+42BasCaYs9bA5xV0gHd/XUz60so9atNyF9eBC6P261pKcdsSpqlNbmKy1bvLvZQWdlqcYOAxe4+s5z96gFflXewL7/8ktNOOy3BlxaJs24d/PKXMGoUHH44DB0KZ54ZdVQiIlJMixbw5JOwdGknbr016mjgb38LMQ0Z8gONXEmu2e7uHZN5QDNrTSgD/ANhNKoZcBfwENA/ma+VDOn+J11WtlpuZmlm9YGLgIfL2e8aoAVh8ltJjw82s7lmNnf79u2JxC2yizuMHBkaVowZAzffHOZWKbESEclIhx8OZ50VGlvs2BFtLOvXh5LACy9USaDkpXXADqBJse1NgNIWTbgJmOPud7n7QnefDAwBLjOzFrF9VlfwmCmTbf+sLyXEXGLSBKENIyGb7efuq0rax92HuXtHd+9YvXoUlZGStZYtC0nUgAFw5JGwYAHccQfUrh11ZCIiUoaCAvjoI3jhhWjjeO452LpVCwdLfnL3rcA8oGuxh7oS+jCUpA4hIYtXdL8ol3m9gsdMmXQnV5XJVuMNAp5y9y9LetDMLiQkXv3d/fmqBCqym61b4Q9/gHbtYP78UAI4fXpYHFhERDLeeedBkybRN7YoLISDDoIT0t4gWiRj3ANcYWZXmlkrM7sPaA4MBTCzUWY2Km7/54HzzOxqMzs01n/hfmC+u38Y2+c+4Awz+42ZHWVmNwGnA/em7beKSWtyVclsFQAzOx44hlJKAs3sIkJidYW7j696tCIxM2bAscfCb38bPp2XLg2XQFXPISKSNWrUgIEDw8K9H30UTQxffx1awqtLoOQzdx9LaJF+C7AAOBk4J67i7ODYrWj/kYSGeD8F3gbGA8uA8+L2mUnoIHgFsJAwF6uPu89O7W+zJ3P39L5gaMU+mlAr+RpwFfAToI27ryrKVN29f7HnPQJ0cfc9elvHOoiMBm4gLCBWZGtpo1xF6tat6xs2bChrF8lXX30Fv/51KNL/3vfgH/+Ac86JOioREamkFSvgsMPC8oO//336X3/UKLj8cpg1SyNXkpvMbKO71406jiilPbmCsIgw8CtCt4+3gZ+7+6uxx6YBuPtpcfvXIywudru7/6WE400jrHVV3CvxxymJkivZgzuMHQvXXx86Al5/ffgUrpvXfytERHLCj34UehCtWhVWzUinH/8YFi0Kixqbpfe1RdJByVVEyVUmUXIlu1mxAoYMCa2cOnYM61a1bx91VCIikiTPPBMWFn7mmVDpnS5ffRXmfP3sZ3B38QVpRHKEkqvs6xYokhrbtsFdd4UGFTNmwH33hboNJVYiIjnlxz+G5s3T39ji2WfDR426BIrkNiVXInPmwHHHwa9+BWefDUuWhEuL1apFHZmIiCRZ9erwk5+EAoWVK9P3uuPGhem7xx2XvtcUkfRTciX565tv4Npr4cQT4fPPYcKEUCdy0EFRRyYiIil05ZVhztMjj6Tn9b76KnQJvOgizbUSyXVKriQ/Pf00tG4NDz4I11wT2qtfcEHUUYmISBocfHBobDF8eCjVS7VnnoHt20MLdhHJbUquJL989BGcfz707AmNGsHrr8MDD8C++0YdmYiIpFFBAaxeDc89l/rXKiyEli1DnyQRyW1KriQ/7NgB998fRqumTIE//xnmztVCIyIieepHP4IWLVLf2OLLL+Gll1QSKJIvlFxJ7luwAE46Ca67Djp3hsWLQ/OKGjWijkxERCJSvXqYe/Xii/D++6l7naKSQHUJFMkPSq4kd23YADfeGOowVq2CMWPghRfgkEOijkxERDLAlVeGxrAPP5y61ygshEMPhR/8IHWvISKZQ8mV5KZJk8KaVXffDQMHhoYVF1+smgwREfmfAw8M6149+ihs3Zr843/xRSgJ7N1bHz8i+ULJleSW1auhTx/o3h3q1IFXX4Vhw6Bhw6gjExGRDFRQAGvXhvK9ZHv66TDlVyWBIvnD3D3qGCJVt25d37BhQ9RhSFV98QWMHg233QabNsEtt4R5VbVqRR2ZiIhksB074LDDwm3q1OQe+4c/DPO5li/XyJXkBzPb6O51o44jShq5kuy1cSM8+ST06AFNm8LPfx6K2hctgltvVWIlIiLlqlYNBg2C//43JEHJsm5dSNbUJVAkvyi5kuyyfTv85z9w2WVwwAFhHtWbb8L114efU6fCEUdEHaWIiGSRgQND98Bhw5J3zKKSQC0cLJJfVBaossDM5w5z5sDjj8PYsaE4fr/94MIL4ZJLoEsX2EvXCUREpPJ69YJXXoFPPklO4UPXrrByJSxbppEryR8qC9TIlWSyd9+F3/4Wvv99OPHEcEmxS5dwOXD16tA797TTlFiJiEiVFRSE6btPPVX1Y33+eSgzVEmgSP7RyJVGrjLLp5+G0anHH4d588Kn0hlnhBGqnj2hfv2oIxQRkRy0c2e4lteiRRjBqophw0KytmABHHNMcuITyQYauYLqUQcgwvr1MGFCSKhefjl8wnXoAPfcE9qqN28edYQiIpLj9torNLa46aawNGKrVpU/VmFhmP7brl3y4hOR7KB6KonGli2hvK93b2jSJMwmXrkSbr45fKrNnRu6/ymxEhGRNBkwoOqNLdauDdcJtXCwSH7SyJWkz86dYVHfxx+H8ePh669Dx7/Bg0PZ3/HH65NIREQi06RJqEB/7DG4806oXbvix5gwIXzcaeFgkfykOVeac5Va7vDWWyGheuKJ0Iapbl244IKQUJ11VrhMKCIikgH++18480wYNSqs+lFRZ5wRpg8vXarrhZJ/NOdKyZWSq1RZuRLGjAlJ1ZIlIYHq1i0kVOeeC3XqRB2hiIjIHtzhyCNDYcWMGRV77po1oZr95pvh9ttTE59IJlNypbJASaZ168Is3scfh5kzw7aTT4Z//jOsSdW4cbTxiYiIlMMsVKvfeCMsXgxt2iT+XJUEiohGrjRyVTUbNsCzz4ZRqsmTYfv28El0ySVw8cXQsmXUEYqIiFTIunVw4IGhnfr99yf+vNNPD8swLlmikkDJTxq5UnKl5Koytm+HF18MI1TPPBMSrBYtoF+/kFQdfbQ+VUREJKv16weTJoX5U4lUsq9eHUoCb70Vfv/71McnkomUXKksUBLlDrNmhRGqsWPD8vP77bcroTrllLBIiIiISA4oKAh9mAoL4Yoryt//qafCR6VKAkXym0auNHJVtnfeCSNUY8bABx/A3ntDjx4hoerWDWrVijpCERGRpHOH1q2hfv1wbbE8p50WrjsuXpzy0EQylkautIiwlOSTT+Cvf4UOHcIS9XfeCYcdBo8+GlohFRbCeecpsRIRkZxV1Nhi9uywokhZPvssLOOoUSsRUXIlwfr1MGJEWNzjoIPghhtCmd/f/gYffwxTpoS6iH33jTpSERGRtLj88nAd8aGHyt6vqCSwd+/0xCUimUtlgflcFrh5c5itO2YMTJwIW7bA4YeHkr9+/eCII6KOUEREJFL9+4feTZ9+CvvsU/I+XbrAl1/C22+nNzaRTKOyQI1c5Z8dO+Dll+HKK6FpU+jVC6ZPDzN3Z8+GZcvgttuUWImIiBA+Hr/9Fp58suTHP/00LDaskkARAY1c5cfIlTssWBAaUzz5ZJhTtc8+0LNnGKU64wyorsaRIiIixbmHFUZq14Y33tjz8QcegJ/9LKxt1apV+uMTySQauVJyldvJ1QcfhJK/MWNg6dKQQP3oRyGh6tEjsYU7RERE8lxRAjVvHvzgB7s/dsop8PXXsGhRNLGJZBIlVxGVBZrZEDNbYWabzWyemZ1Sxr4jzcxLuG2I26eZmY0xs3fMbIeZjUzLL5KJPv8cHnwQOnUKHf5uvRUaN4ahQ8MKh889B336KLESERFJ0GWXhZGr4o0tPvlEJYEisru0J1dm1ge4D7gTaA/MBF4ws4NLecp1QLNitw+Awrh9agHrgP8DZqcm8gy2YUMo+eveHZo1g5/+NBSI/+lPsHJl6A9bUACNGkUdqYiISNbZb79wXXLMmPDxWmT8+PBTXQJFpEjaywLNbDaw0N0HxW1bDox395sSeH5nYAbQ2d1nlvD4RGCdu1+RSDxZWxa4bRu8+GJIqp55BjZuDC3U+/ULZX9HHx11hCIiIjlj1iw46aRQCFJQELZ17gzffVf+Olgi+UJlgZDWLgZmVhPoANxd7KEpQKcEDzMIWFxSYlWBOAYDgwFq1qxZ2cOknzu8/npIqAoLYd06aNAg1Cv06wcnnxzWphIREZGkOuEEaNcuJFeDB4eSwJkz4Y47oo5MRDJJulvENQaqAWuKbV8DnFXek82sPnARUO4IV1ncfRgwDMLIVVWOlRZLl4aEaswYWLEC9t4bzj03jFB16wbZlCCKiIhkIbMwYnXNNaFr4MzYJV6VBIpIvGzrv30pYZ7Y6KgDSblPPoEnnghJ1YIFYUTqrLPCGlQXXAD16kUdoYiISF655BK48cbQ2GLpUjjmGC0LKSK7S3dytQ7YATQptr0JsDqB5w8CnnL3L5MdWEb4+mt46qmQUE2bFsoAjzsO7r03zKRt2jTqCEVERPJW/fpw8cXhY3rzZvjjH6OOSEQyTVon6Lj7VmAe0LXYQ10JXQNLZWbHA8cAD6cmuohs3hwSqp49oUkTuPJK+Phj+N3vYNkymDMHrrtOiZWIiEgGuOqq8NENKgkUkT1FURZ4DzDazOYArwFXAc2BoQBmNgrA3fsXe95gYLm7TyvpoGZ2bOw/9wV2xu5vdfclSf8NkunJJ2HAgJA8DRkSGlN07BiKu0VERCSjdOwIxx8fiku+//2ooxGRTJP25Mrdx5pZI+AWwppVbwPnuPuq2C57rHdlZvWAvsDtZRz6zWL3ewCrgJZVjTmlevaEAw+E00+H6tk2BU5ERCT/TJoUkisRkeLSvs5Vpsnada5ERERERDKI1rlK85wrERERERGRXKXkSkREREREJAmUXImIiIiIiCSBkisREREREZEkUHIlIiIiIiIcdy+iAAANHElEQVSSBEquREREREREkkDJlYiIiIiISBIouRIREREREUkCJVciIiIiIiJJoORKREREREQkCZRciYiIiIhI2pjZEDNbYWabzWyemZ1Sxr4jzcxLuG0ott81ZrbUzDaZ2btm1j/1v8melFyJiIiIiEhamFkf4D7gTqA9MBN4wcwOLuUp1wHNit0+AArjjnk18GfgdqAN8DvgQTPrkaJfo1Tm7ul+zYxSt25d37BhQ/k7ioiIiIhIqcxso7vXLWef2cBCdx8Ut205MN7db0rgNToDM4DO7j4ztm0mMNvdfx6331+BE9z95Mr9NpVTPZ0vlokaNmzItGnTog5DRERERCTbVTezuXH3h7n7sKI7ZlYT6ADcXex5U4BOCb7GIGBxUWIVUwvYXGy/TcDxZlbD3bcleOwqy/vk6ssvv+S0006LOgwRERERkWy33d07lvF4Y6AasKbY9jXAWeUd3MzqAxcBxUe4JgM/MbMJwFxCAnclUCP2mp8lFH0S5H1ytXHjRjezTRGHUR3YHnEMuULnMjl0HpNH5zI5dB6TR+cyOXQek0PnMXky4VzWTvHxLyX0jBhdbPsfgKaE+VtGSNYeA34F7ExxTLvJ++TK3SNv6mFmc8vJ8iVBOpfJofOYPDqXyaHzmDw6l8mh85gcOo/JkyXnch2wA2hSbHsTYHUCzx8EPOXuX8ZvdPdNwEAzK4gd6zNgMPAt8HlVg66IyBMLERERERHJfe6+FZgHdC32UFfCqFOpzOx44Bjg4TKOv83dP3b3HUBfYKK7a+RKRERERERy0j3AaDObA7wGXAU0B4YCmNkoAHcvvk7VYGC5u08rfkAzOwI4AZgFNAB+AbQFLk/Nr1A6JVeZYVj5u0iCdC6TQ+cxeXQuk0PnMXl0LpND5zE5dB6TJyvOpbuPNbNGwC2ENaveBs5x91WxXfZY78rM6hFGom4v5bDVCAnVkcA24GWgk7uvTG705cv7da5ERERERESSQXOuREREREREkkDJlYiIiIiISBIouRIREREREUkCJVdpYGZDzGyFmW02s3lmdkoZ+zYzszFm9o6Z7TCzkWkMNeNV8Fz2NLMpZva5mX1rZrPN7Nx0xpupKngeTzWzmWb2hZltir03b0hnvJmsIuey2PNONrPtZvZ2qmPMBhV8T55mZl7C7ah0xpyJKvp+NLOaZnZ77DlbzOxDM/tZuuLNZBV8T44s5T25IZ0xZ6JKvCf7mdkCM9toZqvN7F9m1jRd8WaySpzLa8xsaeyz+10zK959T1JAyVWKmVkf4D7gTqA9oYf/C2a2RyeUmFqEBdb+D5idliCzRCXO5anAf4Husf0nAU8n+uU3V1XiPH4H3A90AVoDdwC/N7MhaQg3o1XiXBY9rwEwCpia8iCzQGXPI9CG0Gmq6LY8lXFmukqexyeBboQWx0cCvYGFKQ4141XiXF7H7u/FZsAHQGHqo81cFT2PZtYZGA08Rvj3fT7hc+fxtAScwSpxLq8G/kzortcG+B3woJn1SE/E+UvdAlPMzGYDC919UNy25cB4d7+pnOdOBNa5+xWpjTI7VOVcxu0/B5ju7r9MUZgZL0nncQKwxd0vTlGYWaGy5zJ2/t4CDLjQ3dumPNgMVtHzaGanEdrs7u/u69IWaIarxHk8GxgHHKbzuLuq/p2MJQkzgM7uXubCqLmsEu/JG4Br3f17cdsGAA+4+z7piDlTVeJczgRmu/vP47b9FTjB3U9OR8z5SiNXKWRmNYEOwJRiD00BOqU/ouyVxHNZD/gqWXFlm2ScRzNrH9v3leRGl10qey5jI35NCCOAea+K78m5ZvaZmU01s9NTEmCWqOR5PB94A/iFmX1sZsvN7H4zy/cvscn4vBkELM7zxKoy5/E1oJmZ9bCgMWFto0mpizTzVfJc1gI2F9u2CTjezGokN0KJp+QqtRoTFjVbU2z7GkD1wxVT5XNpZtcALQglB/mq0ucx9uVrCzAX+Ie7D01NiFmjwufSzI4mlGZc6u47Uhte1qjMe/Iz4GqgF9ATeBeYmuclv5U5j4cCJwPHEM7lTwklgiNTE2LWqNLnjZnVBy4CHk5+aFmlwufR3V8nJFOPA1uBzwkj/JenLsysUJn35GRgoJkdF0tUOwJXAjVix5MUqR51ACLpYGa9gLuAPnErgEvFnALsA5wI/NnMVrh7PieqFWJmtYCxwA3uviLqeLKZu79LSKiKvG5mLYEbgelRxJSl9gIc6Ofu6wHM7KfAZDNr4u7Fv8hJYi4lnFv9fawgM2sNPAD8gZAcNCN8dj8EqBlDxfyBkHjNJCSoawhz2X4F7IwwrpynkavUWgfsIJQAxWsCrE5/OFmt0ufSzC4kfMj1d/fnUxNe1qj0eXT3Fe6+yN0fBu4BbktJhNmjoueyGdAKeNRCl8DtwG+BNrH7Z6c02syVrL+Ts4HvJyuoLFSZ8/gZ8ElRYhWzNPazvGYiuayq78lBwFPu/mWyA8sylTmPNwFz3P0ud1/o7pOBIcBlZtYidaFmvAqfS3ff5O4DgTpAS8K/6ZXAt4QRQUkRJVcp5O5bgXlA12IPdSVcSZAEVfZcmtlFhMTqCncfn7oIs0MS35N7Eeq581YlzuUnwNHAsXG3ocB7sf/Oy78JSXxPHktIFvJSJc/ja0DzYnOsjoj9zNsR/qq8J83seEKZZb6XBFb2PNYhJBHxiu7n7XfWqrwn3X2bu38cK0XvC0x0d41cpZDKAlPvHmB0rEvda8BVQHPClyrMbBSAu/9vuNvMjo39577Aztj9re6+JJ2BZ6AKnUsz60tIrG4AXo1bJ2Nrnl9RrOh5vBZYwa4yrC6Ec/qP9IadkRI+l+6+DdhtTSszW0voupjva11V9D15PeEK7GKgJqEM63zCvKF8VtHPmzHArYTR1NuA/Qitnse7+9r0hp5xKvzZHTMYWO7u09IXakar6Hl8Hng41ka8qCzwXmC+u3+Y5tgzTUX/Th4BnADMAhoAvwDaovlrKafkKsXcfayZNQJuIfyReBs4J27eT0mlF28Wu9+DcBWxZarizAaVOJdXEd7j98ZuRV4BTktttJmrEuexGmGtjJbAduB94DfE/qDns0r++5ZiKnEeaxLmYbQgdL9aDHR397zuKFbR8+ju35nZWYQ5Lm8QOqk+Q/j3ndcq82/bzOoRRgZuT1ugGa4S78mRsfP4U+CvwHrCepW/Tl/UmamSn92/IKxft42wfEUnd1+Znojzl9a5EhERERERSYK8rV8VERERERFJJiVXIiIiIiIiSaDkSkREREREJAmUXImIiIiIiCSBkisREREREZEkUHIlIiIiIiKSBEquRETymJndZmYeu90WdTwlicV4m5ldkcC+LeN+n/JuI1MfvYiI5BMtIiwiIpnud7GfrwAjI4xDRESkTBq5EhGRnOHuK93dim7A6XEPvxL/mLtfEVGYIiKSo5RciYj8/3buHcSuKorD+PcXEyIMPiCIpnCigiCC1k6j+EIQQQRTJIUTiIVFrES0EbHQwkpr0VGihSg2aiEIESH4aESUEIMRtRCDcZBhlInKsjhnyGa8d46PMxnGfD+4nL33XfecdavLYq+79RdJFpr2ubkkh5IsJjmV5I0klzWxbSveQpL9SY4mWUlybG07X5LDq/HrrSeZXxNzU/OcwyN+16eSfJTkhySnkywn+TTJI0m2NXF3Ns9/dGhdknTusS1QkjTkbeDiZn4vcBFw24TYu4D7m/k1wItJzquqFzYuxf9kLzDbzLcBN/SvK4EHNyMpSdLW486VJGnI18DVdIXSyX7t1iSXT4jdSVdcXQjsa9afbneB/o6qWuhb+1a1bX03/5N7DXgYuJauYNxO9z2/6N87kGRmxGdJkv7HLK4kSUMer6oTVXUc+KBZn50Qe6SqXq6qpap6FTjSr18KXL/Rif5Ly8BzwFfAr8CXwHX9e+fTFZaSJA2yLVCSNORYM15uxjsmxH47YT7Xj3cOPOes/yYluYWu7THrhF0wcBt/SyVJgDtXkqRhvzXjmhrVuWKd+Y/9dWV1IcmO/hq6/zedbXs4U1g9Ccz0rYjvTIhdacZtYXnVBuUmSdpiLK4kSWOaS7IvyUySvZzZtToJfNaPv2ni7+6vB4FdU+55qr/OJrlk1Gzh92a8BPyR5B7g9gmxbd53JNmeZBfw0Mg5SZK2KIsrSdKYvgcO0RUqrzTrj1XV6g5Yu/5akiXgWbr/O03yYX/dDfzUH3n+xEj5vtmMn+lzeB34bm1gVZ1ocrkRWOzjJh3sIUk6B1lcSZLG9C7dKYFHgdPAcWB/ewx7Vb0PHKA7OGKF7iCJ+4CPp9zzIF2b3uLYyVbVe8B8k8vndEfNfzLlI3uAt4CfgV+A54EHxs5LkrQ1pWqofV6SpOmS7KY7rh3gpaqa37RkJEnaRO5cSZIkSdIILK4kSZIkaQS2BUqSJEnSCNy5kiRJkqQRWFxJkiRJ0ggsriRJkiRpBBZXkiRJkjQCiytJkiRJGsGf2MMkadTQBb0AAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA18AAAHGCAYAAACLsDHLAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAIABJREFUeJzs3XecU2X2x/HPoSMWwIIdLKgIKljAQhRWUSmKOth7wY4i6q76w7Lqrr0ggq5tWV27YwkuKKICKiiKBRUFFAsWqqJIL8/vj5OROE7JzCS5Seb7fr3yykxyc+/J1Hvuc57zWAgBERERERERyaw6UQcgIiIiIiJSGyj5EhERERERyQIlXyIiIiIiIlmg5EtERERERCQLlHyJiIiIiIhkgZIvERERERGRLFDyJSIiIiIikgVKvkRERERERLJAyZeISBWY2XgzC0m3NlHHJKkzszFJ37tWUccTFTP7utTPcXm3r6OOVUSkkCj5EhFJkZltA+xV6uETo4hFRERE8o+SLxGR1J1QxmPHmZllPZIqMLNGUccguSWE0CqEYCW3Us9Z0q1VRCGKiBQkJV8iIqk7PnG/BHgi8XFLYN/SG5rZrmb2uJl9b2bLzWyemb1uZh2ruM3vZXKl9v+nx81sWFK5WMzMnjGzX4DPEs8fbWavmNlMM1tsZsvMbIaZ3WtmLaryHszszqRjdSr1uvcSj/9sZo3L+2JWJZ5S721vM/tvYv/zzazYzDYuY/+nmdl0M1tqZh+Y2UHlxVJOfM+Y2Wwz61nGc0+a2edm1qAq+0zxuHckvdc9Sz33TuLx38xsHTPbysweNrNvE+9zgZl9kvh6bZTGmKryvUr5Z1ZEpNYJIeimm2666VbJDdgTCInbs8DBSZ/fX2rbw4EVSc8n305JdZvEdmNKHi91jD89DgxL2se8pI+/Tjx/bznHC8DnQINU3wOwNbAq8fm/k17XOmm7IZV8TasST/J7+7mM7UeX2vcpZWyzApiT9HmrSuLrmIjjtVKP7594/QEZ+lnbOSnGQUmPb5P0+LDEY59W8DVsV4Vj/v66NHyvUv6Z1U033XSrbTeNfImIpCa55PAZ4FVgQeLzPmbWECAx0nM/UC/x3FVAC2AD4EhgRirbpCHeX/H5aY2BHonHHgM6JY5TP3HMfyee275ku1TiCyHMAIYnnj/azJomPj4mKYb7K4kxpXjK8BWeiGyHJ1MA+5vZJon46wD/SNr+JGBd4K/AhpXE9LsQwkTgUaBdyWNmVh+4G3g6hDA61X1VRQhhMjAp8elRZlY38fGxSZs9ZGbrAzsmPr8LaAI0B/YArgR+SWNY1f1eiYhIEiVfIiKVSJxwH534dBnwYghhBWuSj6bAIYmP9wHWT3w8JoRwXQhhTghhfgjhmRDCuBS3qamBIYS3QwhLQwhTEo/9CPQDPgAWA7OBU5Nes30V3gPAHYn7xsDJiY9Lvk6TQggfVhJjqvGUdlUIYUYIYTrwRtLjLZNet2ni4w9CCI+EEBaGEO4AZlYSU2lTgA0TiQ7AAGDzxD0AZnaUmU02s/fNLJb8YnM/mVnKSV/CQ4n7jYGuiY9Lkq8vEt+Dn1lzAaA7cAWeBC0NIVwfQqjqe61Idb9XIiKSpF7lm4iI1HoH41f8Ad4HtjTvsfERa7odnoCPiCXPf5lC2VLZpjKV/f3+IPkTM1sPeBOoaB5QyfyslOILIYw1sw+ADsBZZvYa0Dbx9AMVBVfFeEqbmvTxoqSPSxqLrJ/02HelXvs9sEVFsZXyeeK+jXnb9SuBv4cQvgNProA7gX1DCF+U8frWwK8hhLnJDyZeZyGE1eUc9zHgNvw9HWdmc1kzyvUQQAhhtZmdCNyTOM7/Je3/E6BHOhKwGn6vkumcQ0RqPY18iYhULrnkcC/g48Tt1qTHu5tZc3xEoER5a4Clsk2JZSUfWKJrYeLEfatKXrek1OddWXPy/CqwSfAudxfUML5BSdsNTny8GE8eKlKVeEpbkfRxWc0b5iV9vHmp5zZLYf/JpuNz29rgI33f4MkWZtYMT86aAs+Y2aVm1tTM/mNmn5rZm3iZ5ruJ7a9NNAoZjjdB+VOTkN/fVAgLgOcTnx6Bz2EjEct/krZ7EdgSH3k6FLg2sU07YGAV32t5qvq9qu7PrIhIwVPyJSJSATNblzUlhRVpgJfcvQXMTzzW1cyuMLMNzayZmR1mZvumuE2Jb5I+LomjH2vK6lK1MunjpcAiM2ub2FdpVYnvcdYka/sl7p8KIfyaxniqahrwQ+LjDmZ2YqIz4EVUbdSLEMJy4EvgTKAPcH6i5JQQws/4aNOoEEL7EMIt+OjnhyGEtnjTkktJJF/AbniidEIIYYcQwg9UrKT0cD3g/MTHLye/zswG4w1AfgNeAopZk/xsWZX3WoGqfq/S9TMrIlJwlHyJiFSsD2tKqp4Kf1wDyYADk7Y9IYSwBOjLmhPWf+BNIX4CngO2TmWbpH0+mvTxU2a2EB9tKj2yVZm3gJLSt554Q45PytqwKvElkpOhpXZRYclhVeOpqkQp3/8lPfRwYv+34vOkquozYHfgiRDC66We2x14DyCRlG6YmFtGotRwNn9Mvi4MIaTaCONV4NvExyUlew+V2uYc4BW8nHI5Xgq7VuK5l1M8TmWq+r1K18+siEjBUfIlIlKx5JLDh8t4/lX8xBdgbzPbOoTwHN4Z7gl8BGYlnriMJTGHKpVtEtuNBc7AR3OW4aMwRwITq/ImEqM03fG5O4sTx7wGuLGc7VOKL+Ee1oy2fBZCeCvd8VRVCGEYcDr+9VqOl4keAUyuxu6+wEd8Li7jud1IJF94l8Hfvy+JdbZaAZPMbHOgXgjhgz/toRyJJHJY0kPzgHipzW7Ev4Zz8O/RYnxe4gWsKQmtkWr87KTlZ1ZEpBBZCFrrUEREqs/MdsSTmrr4yM5dEYeUVmb2JLBFCGHvMp6bD+wQQphrZicB5+HdIg0fAdophNDGzHoDZ4cQumczdhERyS0a+RIRkWoxs8PNbBreWbEu3lkwlZLDfLMba9bd+p2ZbQ38ltTJ8Cl8BOpzfISwPn8sOXy39D5ERKR2UdtXERGprvXwFudL8fW2zg0hLI42pPRKtFnfGi/l+4PEQtMtkz5fSjnNWUIIV2UqRhERyR8qOxQREREREckClR2KiIiIiIhkgcoOU1CnTp3QuHHjyjcUEREREZFyLV68OIQQau0AkJKvFDRu3JhFixZFHYaIiIiISF4zs1q95l+tzTpFRERERESyScmXiIiIiIhIFij5EhERERERyQIlXyIiIiIiIlmg5EtERERERCQLlHyJiIiIiIhkgZIvERERERGRLFDyJSIiIiIikgVKvkRERERERLJAyZeIiIiIiEgWKPkSERERERHJAiVfIiIiIiIiWaDkS0REREREJAuUfImIiIiIiGSBki8RERGRNFvwzS+sXL466jBEJMco+RIRERFJo8XTvmObrVZxy3b3w7x5UYcjIjlEyZeIiIhIGo0++RF+Cs156dsdoWNHmDIl6pBEJEco+RIRERFJlxEjiL+9IQDv1N+HZYtWwl57wcsvRxyYiOQCJV8iIiIi6bBkCavPv4DhdQ9jgw0Cy5bX4b173oWttoIePeDuu6OOUEQipuRLREREJB1uuIGJX23AnFUbcOWVBsAb01rAm29Cr17Qrx+cdx6sXBlxoCISFSVfIiIiIjU1bRrcdBPxtldQty6ceCK0aQNvvAGsvTY8+yxceikMHQo9e8KCBVFHLCIRUPIlIiIiUhMh+IhW48bEV3Zn332hWTOIxeCtt2DVKqBuXbj5ZnjoIXj9dZ8H9uWXUUcuIlmm5EtERESkJp5+GkaP5sv+g/l0an0OPdQfjsXgl1/gk0+Stj31VHjlFZgzBzp1gnHjIglZRKKh5EtERESkun79Ffr3h113Zfi6xwNwyCH+VCzm92+8Ueo1++0HEyfChhvCAQfAv/+dvXhFJFJKvkRERESq65prYNYsuOce4i/WoW1b2GYbf6plS9hiizKSL/CNJkyALl3gtNPgr39N1CeKSCGLJPkys3PN7CszW2pmk8wsVsG2w8wslHFblLRNl3K22aHUvorMbIqZLUvcH57J9ykiIiIF7KOP4K674Kyz+Ll1R8aN4/eSwxKxmCdfIZTx+qZNYcQIOPdcuOUWKCqC337LSugiEo2sJ19mdjQwCPgn0AEYD4w0sy3LecmFwCalbjOAp8rYtm2p7aYnHXcv4EngUaB94v5pM+tU83clIiIitcrq1Z40NW8O//wnI0f6wFVZydePP8KMGeXsp149GDIEBg+G4cOhc2eYOTPj4YtINKIY+RoADAsh3B9C+CyE0A/4ETinrI1DCL+EEGaV3IBtgK2B+8vYfE7ytiGE5PH7/sDrIYR/JI77D2BM4nERERGR1A0bBuPH+4hVs2bE47DRRtCx4x83K3feV2nnnw//+x989ZXvZOLETEQtIhHLavJlZg2A3YBRpZ4aBeyd4m76Ap+GEMaX8dx7Zvajmb1qZl1LPbdXGcd9uQrHFREREYH5832OViwGJ53E8uUwcqQ32qhT6syqTRsfHKs0+QI4+GCfB9a4sTflePLJjIQvItHJ9sjXBkBdYHapx2cDG1f2YjNbDziKP496lYycFQFHAFOBV0vNJdu4Ksc1szPN7D0ze2+lVqIXERGREpdd5j3khw4FM8aN86aHpUsOwZOxzp1TTL4AdtwR3nkHdt8djjkGrr22nAljIpKP8q3b4Ql4zI8kPxhCmBpCuDeEMCmEMCGEcC7wEnBpdQ8UQrgvhLB7CGH3evXq1SxqERERKQwTJsADD8BFF0G7dgDE49CokXeNL0ssBtOne1PElGy4IYweDSefDFdfDccfD0uWpCd+EYlUtpOvecAqoEWpx1sAqfxJ6gsUhxB+SmHbd4DWSZ/PqsFxRUREpLZbuRLOOQc23xyuugrwQal4HLp1g7XWKvtlJfO+3nyzCsdq2NDX/7rxRnj8cejatQrZm4jkqqwmXyGE5cAkoFupp7rhXQ/LZWYdgV0ou9FGWdrj5YglJlTnuCIiIiKAdyX86CMYNAjWXhuAjz+Gb74pu+SwxK67emKWculhCTP429/g2Wf9QB07wuTJ1Y9fRCIXRdnh7cApZnaGmbUxs0HApsC9AGb2sJk9XMbrzgSmhxDGlH7CzPqb2WFm1trM2prZDcBhwN1Jmw0C/mJml5nZDmZ2OdAVuDO9b09EREQKzg8/wJVXQvfucPiaZULjcb/v1av8l9avD3vuWY3kq8Thh/uw2erVsPfe3pJeRPJS1pOvEMKTeHv3gcCHQGegRwjhm8QmWyZuvzOzdYBjgAfK2W0D4BZgMvBGYp89QwjPJh13fGIfpyS2Owk4OoTwTlremIiIiBSuiy+G5ct9PS6z3x+Ox6FTJ9i4krZhsZgPmv36azWP36GDt59v0wZ694bbblMjDpE8ZEG/uJVq0qRJWLRoUdRhiIiISBRGj/ZJXX//++9zvcAHwzbbDP7xD7jiiop38eqr3pBj5EjvKF9tixd7I45nnoHTT/eOiw0a1GCHItllZotDCE2ijiMq+dbtUERERCR7li2D886Dbbf1tb2SvPii3/fuXflu9twT6tWrQelhibXW8vW/Bg6EBx+Egw7ydcdEJC8o+RIREREpz623wrRp3myjUaM/PBWPw9Zb+9JclWnSxBtv1Dj5Al887Lrr4L//hfHjPbObOjUNOxaRTFPyJSIiIlKWr76C66+HI4+EAw/8w1OLFnk14qGH/mEKWIViMZ+2tWxZmuI7/ngYM8Ynku25pwckIjlNyZeIiIhIaSFAv35eK3jHHX96+pVXPImqqMV8abGYv+bdd9MY5157wTvv+NpjBx8M996bxp2LSLop+RIREREp7YUX4H//8yYbm232p6fjcWjaFDp3Tn2XJdumpfQwWatW8NZbnnydcw707+8LQotIzlG3wxSo26GIiEgtsmiRt3Rv2hQmTfKFupKsWgWbbOINEB99tGq7btsWWraEESPSGG9yYJde6iN13bvD44/Deutl4EAi1aduhyIiIiKyxnXXwcyZcM89f0q8wKv85s6tWslhiVjMB6lWrUpDnKXVrQu33w7/+pfXRe6zj89bE5GcoeRLREREpMSUKb6A8WmnefJShnjcp4JVZ72uWMz7Y3z8cQ3jrMiZZ8LLL8P330PHjp7tiUhOUPIlIiIiAt5k49xzYd114aabyt0sHocuXapX0ReL+X3a532V9pe/+BBds2b+8SOPZPiAIpIKJV8iIiIi4BO4xo6FG2+EDTYoc5Pp0+Gzz6pXcgiw5ZZ+y3jyBbDddvD22z6Cd9JJcMUVsHp1Fg4sIuVR8iUiIiKyYAFcfDF06gSnn17uZsOH+/0hh1T/ULGYJ19Z6XnWvLmXIPbtCzfc4GuWqYmYSGSUfImIiIgMHAjz5nmTjTrlnx7F47Dzzt7dvbpiMZg1C778svr7qJL69b0Jx+23w3PPwb77+nwwEck6JV8iIiJSu02aBEOHwvnnQ4cO5W42fz68+Wb1Sw5LZG3eVzIzuOgiH7qbNs0bcUyalMUARASUfImIiEhttmqVL0zcogVce22Fm44c6ZvXNPlq0wbWXz/LyVeJnj1h/HgfDYvFoLg4giBEai8lXyIiIlJ73X8/vPuul+RV0r4wHvfFlXfbrWaHNIPOnSNKvgB22sk7IbZvD336wD//maUJaCKi5EtERERqpzlz4PLLvRX7McdUuOmyZfDSS95oo4IpYSmLxeCLL3zuVyRatIDXXoPjjoP/+z84+WR/kyKSUUq+REREpHa69FLv/DdkiA9HVWDsWFi4sOYlhyUimfdVWqNG8N//wnXX+Tpgf/mLJ6QikjFKvkRERKT2GTsWHn7YE7Addqh083gc1lrL85N06NDB9xdp8gWedA4cCE89Be+/7632P/kk4qBECpcF1fhWqkmTJmGR1sQQEREpDCtW+HynRYtgyhTPgioQArRs6XO9nnsufWEccIB3UPzgg/Tts0befRd694bffoMnn4Tu3aOOSAqQmS0OITSJOo6oaORLREREapc77/Ska/DgShMvgA8/hJkz01dyWCIWg48+gl9+Se9+q22PPWDiRNhmG+jVCwYNUiMOkTRT8iUiIiK1x8yZcM01PsJzyCEpvSQe9+q8nj3TG0os5rnN+PHp3W+NbL75msXM+veHc8/1kUIRSQslXyIiIlJ79O/vGc+gQSm/JB6HvfaCjTZKbyh77gn16uXAvK/SmjTx9b8uuwzuvdfLD3/+OeqoRAqCki8RERGpHUaMgGefhauu8klcKfjuO+9Dke6SQ/CKx912y8HkC7yf/g03wL//DePGeaY4fXrUUYnkPSVfIiIiUviWLIF+/byz4YABKb9s+HC/z0TyBV56OHEiLF2amf3X2CmnwKuvemeQTp1gzJioIxLJa0q+REREpPDdeCPMmAFDh0KDBim/LB6HbbdNqRt9tcRisHy5NxrMWSUZ4sYbQ7du8MADUUckkreUfImIiEhhmz7dk6/jj4euXVN+2cKF8NprPupVyRrM1bbPPn6fk6WHybbeGiZM8IXO+vaFSy6BVauijkok7yj5EhERkcIVApx/PjRqBLfeWqWXjhrlo1KZKjkEWH99aNs2D5IvgPXWg//9z7+et90Ghx3mGaqIpEzJl4iIiBSup5/2LOof//CyuSqIx6FZszWjU5kSi3m7+bwYSKpXz9dHGzIERo70L84330QdlUjeUPIlIiIihenXX721fIcOcM45VXrpypU+yNOzp+cbmRSLeaiTJ2f2OGl17rnePfLbb6FjR3j77agjEskLSr5ERCIyapR3b/7226gjESlQ11wDs2bBPfdA3bpVeumECd7gL5MlhyViMb/Pi9LDZAce6F+otdeGLl3g8cejjkgKhJmda2ZfmdlSM5tkZrFKtj/PzD4zsyVmNtXMTir1fF8ze8PMfjazBWb2upl1zuy7KJuSLxGRCLz5pk+XeOcdePTRqKMRKUAffQR33QVnnukt0qsoHof69eGggzIQWylbbOHLjuVd8gXQpo3/IevUCY47Dq6+GlavjjoqyWNmdjQwCPgn0AEYD4w0sy3L2f4c4CbgWqAtcDUwxMwOSdqsC/Ak8BegEzAVeNnMWmfobZTLQgjZPmbeadKkSVi0aFHUYYhIgfjwQ79I3KIFNGzoXa/fey/qqEQKyOrVPpw0bRpMnQrNm1d5F9tvD61awcsvpz+8spx4IrzyCvz4Y+Y6K2bU8uVw9tm+KPNRR8GwYdC4cdRRSQ4ys8UhhCYVPP8OMDmE0DfpsenAMyGEy8vYfjzwTgjhoqTHbgM6hRDKHN0yMwN+BP4RQhhc/XdTdRr5EhHJomnTvFJn3XX9ROvEE2HSJPj666gjEykgw4Z5B4tbbqlW4jV1qv+uZqPksEQsBrNnwxdfZO+YadWgATz4INx8szc52W8/zyRFqsDMGgC7AaNKPTUK2LuclzUESi9TvgToaGb1y3lNA6AR8HM1Q622DE8hLQzNmzdnjFZ0F5Eamj27IRdc0IEVK+pw220fMGPGEjbbrBGwJzff/AVHHfVd1CGK5L9Vq7z9+b33+tBVNf5/P/HEFsA2bLDBBMaMWZbuCMvUsOFaQEfuv/9zevSYlZVjZsQee8Bzz/mC1s884ytUawRM/qiemSXXe9wXQrgv8fEGQF1gdqnXzAYOKGd/LwOnm9mzwHt48nYGUD+xv7KuAlwP/AbEq/UOakBlhylQ2aGI1NScOWuubI8ZA+3br3lu1119CaLx4yMLT6RwnHkmPPSQ1/e2a1etXcRi8Ntv8MEHaY6tAiHARhtBr15euZf3PvwQDjkEfv7ZJ7b27h11RJIjKio7NLNNge+B/UII45Ievwo4PoSwfRmvaQwMAU4EDE/U/gv8Fdg4hDC71PYXAtcBB4QQJqbnXaVOZYciUnVTp2pdlypYsMAn7c+c6a2rkxMvgKIibxj2/ffRxCdSMN5+G+6/Hy66qNqJ19y5fiEkmyWH4PO8OnfO06YbZWnfHiZOhB13hMMP93JEXfCXys0DVgEtSj3eAihzSDiEsCSEcBqwFtAK2BL4GlgIzE3e1sz646NePaJIvEDJl4ikatUqeP552H9/2GEH7xixcmXUUeW8xYv9Svann3olTlmLtRYV+f1zz2U3NpGCsnKlr+W12Wbeca+aRozwfh3ZTr7AR9y+/LKApkptsgmMHQtHHgl/+xucfro35hApRwhhOTAJ6FbqqW5418OKXrsihPBdCGEVcAzwYgjh99abZjYAH/HqGUJ4M72Rp07Jl4hUbP58v2K5zTZ+9XL6dDj5ZO8Q8eyzUUeX05YvhyOO8FGtRx8tv2X1Djv4xeHi4uzGJ1JQhg71UrdBg3zdqWqKx2HTTb0cONvydr2vijRu7Ot/XXWV11N26wbz5kUdleS224FTzOwMM2tjZoOATYF7AczsYTN7uGRjM9vOzE40s9Zm1tHMngDaAVckbXMpcCNwOjDNzDZO3NbL5hsDJV8iUp6PPoIzzoDNN/crlltt5dnBjBne0WrbbeG221RGUo5Vq+CEE7xN9X33+YXfihQVwbhxXvIkIlX0ww8wcCAcfLBf8aimpUv9d/bQQ6Np996hAzRpUmDJF0CdOvD3v8Njj61ZE+yzz6KOSnJUCOFJoD8wEPgQ6IyXCZbMd9gycStRFxgAfAS8gncx3DuE8HXSNufhDTiexBtwlNwGZeyNlEPJl4issWIFPPUU7Luv1+s/9hicdBJMngyvv+4nNfXqQd26Pqdi4kQf1pE/CAHOOsu7Ld92m1faVKZPHy91ev75zMcnUnAuvtiHmgcPrlHW9PrrsGhRNCWH4H9e99qrAJOvEsce6x2HfvvN3+io0t3ERVwIYWgIoVUIoWEIYbfk5hshhC4hhC5Jn38WQugQQlgrhLBeCOGwEMLUUvtrFUKwMm6nZO9dOSVfIuKt+K6/3ke3jj4avvsObr3VO0D861+w005/fs3JJ0OzZnD77dmPN4eFAJde6oODAwfCgAGpvW6nnXww8ZlnMhufSMEZPRqeeAIuv9x/iWogHveRp65d0xRbNcRifr1rwYLoYsioPff0C3dbbgk9esCQIVFHJJJVkSRfZnaumX1lZkvNbJKZxSrYdpiZhTJui5K2OcLMRpnZXDNbaGbvmNmhpfZzSjn7aZTJ9yqS095910e2ttgCrrzSJx7F4z6v6+KLPbkqT5MmcPbZa9ZzEQD++U8f7Tr/fLj22tRfZ+alh6+95p2ZRSQFy5bBeef5nNS//a1GuwrB//wdfLAv/RCVWMxjKeilJ1q2hLfegu7d/Y9lv35q4CS1RtaTLzM7Gq+v/CfQAe9cMtLMtiznJRcCm5S6zQCeStpmP+A1oGdinyOA58pI6haX3lcIofSK2CKFbfly7/6w557QsaMnT2ee6fX3o0b5uix166a2r/PP920HZb1kOifdfbePdp14on9Jqlr9VFTk5x/xrC/5KJKnbr0Vpk3zX74aZkzvv+9Tx6IqOSzRqRPUr1/ApYcl1lnH66wvvti/f716wS+/RB2VSMZlfZFlM3sHmBxC6Jv02HTgmRDC5Sm8fh/gTWCfEEK514XMbCLwRgjh4sTnpwB3hxCq3AJJiyxLQfjhBy8h/Ne/fKXf7bbz5Onkk2Hddau/35NP9kYc330HTZumL94889//etLVu7eXDtarV/V9hACtWsEuuygBE6nUV1/5aH2vXj7Bsoauvtqrr2fPhg02SEN8NbDXXn5d683ImmFn2QMP+DIBrVvD8OE+kikFq6JFlmuDrI58mVkDYDeg9AzLUcDeKe6mL/BpRYlXwjpA6eKdxmb2jZl9Z2YvmlmHFI8pkp9KaleOPdbLPK67DnbfHV56yUe6+vWrWeIF3nhj0SJf2LSWeuEFOOUU+MtffOpJdRIv8JGyI47wAciFC9MaokhhCcH/ftWtC3fckZZdxuO+Dl/UiRd46eG773r3xVrhjDP8D9+sWT70V/DDflKbZbvscAO8HeTsUo/PBjau7MWJXvxHARWe5ZnZecDmwCNJD08FTgN6A8cCS4G3zKx1Ofs408zeM7P3VqoOWfLN0qUwbJgnWvvsAyNH+onKtGkIY1kiAAAgAElEQVTw4ou+4FSdNP36t2/vWcddd3m3xFrmtde8R8luu3kFTU3nivTp49NY/ve/9MQnUpDicf8l+fvffTmMGvr2W18iLOqSwxKxmFeIT5wYdSRZ1LWrt6Fff33Yf3//HyZSgPKt2+EJeMyPlLeBmRUBtwDHJa0HQAhhQgjhPyGED0MIbwBHA18C/craTwjhvhDC7iGE3etV9zK2SLZ9+y1ccYU30Dj1VD+Lv+ceLwm8/fYadwIr14ABfow0lP7kk4kT/WStdWvPb9dZp+b73Gsv2GQTdT0UKdeiRXDBBdCund+nwfDhfp8rydc++/h9rRsAat0a3n7blzs59VS47DJfg0PSY/VqfT1zQLazinnAKqBFqcdbALNSeH1foDiE8FNZT5pZH+Bh4KQQwvCKdhRCWGVm7wFljnyJ5I0QYOxYX9+mZJGoQw/1ka6uXbOzUmj37rDDDt7m79hjo1mdNMs++cTfdosWXi3TvHl69lunDhx+uF/0XbwY1lorPfsVKRjXX+8Xmt54wztTpEE8Dttv71Nhc0Hz5p5b1rrkC7zLbkm1xk03wdSp8MgjsHYlU/ZXr/bV7Vet8s5FK1eu+Thf79O9zxDg3//2OnmJTFaTrxDCcjObBHQDki+RdwOKK3qtmXUEdsFXvC7r+aOA/wAnhxAqvWZsZgbsjK+GLZJ/Fi3yroV33w0ff+z/rS+91Cctt2yZ3Vjq1PG5X2ed5WcL++6b3eNn2YwZcOCBXmI4erSPVKVTUREMHepT8444Ir37FslrU6Z4h8NTT4XOndOyy19/9cWV+5d5dhGdWMwb+axalXoD2oJRv75XbbRp45UVW24JjRtXnFxkuYFcSurU8W9evXo1u69f3//hJD9e3X21bx/1V6XWi6Lb4dF42eC5wFvA2cDpQNsQwjdm9jBACOGkUq97ANg3hPCn61Jmdkxin5cATyY9tbxklMzMrgbeBqYD6wIXACfiXRMrrKpWt0PJKTNm+Jn5gw/6Kpzt2/sVwmOP9X9OUVmyxMsd99nHO1AUqB9+8HO+X36BceOgbdv0H2PlSth4Y5+a9+ij6d+/SF4KweeXfvSRj4ZsuGFadvv003DUUX7dKE35XFo8/jgcdxxMmgS77hp1NBEaPdq/GOlKZNKRwKR6XwuqQKqjtnc7zPpkphDCk2a2PjAQX2vrE6BH0vysP633ZWbrAMcA5S1Zejb+Xu5M3EqMBbokPm4K3Ic39vgF+ABP5mrTdFbJVyH4P6DBg71hRp06PjzSr58nO7nwB75xYzj3XC8JmjYtd+p30mj+fOjWDebO9UYbmUi8wP9vH3aYnxQuWwYNG2bmOCJ55dFHYcwYXy4jTYkXeMnh+uv7fMtcEkusVPrGG7U8+TrgAL+JFIisj3zlI418SWQWLoSHH/aka+pU2GgjXxD57LNhs82iju7PZs/28pAzzoAhQ6KOJq0WLvQGXJMnezlgly6ZPd5LL/mcshdfhJ49M3sskZy3YIFPymrVCiZMSFu31pUr/c/qoYfmZnO9rbbyTqpqwCOFpLaPfOVbt0OR2mHaNO/itdlmvhDyuut6Evbtt75WVy4mXuDdJ044wSf0/lRmX5y8tGSJn5y9/76PRmU68QKvrlpvPZ10iQAwcCDMm+fzgNK1TAbw1lvw88+50+WwtFjMR750nVykcCj5EskVq1f7ujUHH+xXeO+9188I3n7be5qfeGJ+1J9ddJFnK/feG3UkabFiha/jNXYs/Oc/cMgh2Tlugwb+7X/hhVq5fJrIGpMm+TzX885Le/1dPO6/awcemNbdpk0sBnPmwPTpUUciIumi5EskagsWwB13+BypXr28ru3aa32U67//hU6doo6watq18zOZwYN9wlIeW73am6oNH+5NJY8/PrvHLyryq/JjxmT3uCI5Y9Uq7+C60UY+6p9GIfjFjf33r7yLeVSS532JSGFQ8iUSlU8/9ZOKzTf3VrobbwxPPAHffANXXumf56uLL4ZZs+DJJyvfNkeF4P1MHn0U/vEP7yWSbQceCE2aQHGFC3GIFLD774d33/VF4tdbL627/vxz+PLL3C05BC+C2HBDJV8ihUQNN1KghhuSNqtW+TDK4MHeLq9hQ+8l3K8fdOgQdXTpEwLstJO37fvgg9zoxlhFAwd60nXppb7OZ1Rv4eijfeTrhx9q4Vo/UrvNmePZR4cO8Oqraf8lvOkmuOwymDnTr4HlqiOO8O76X34ZdSQi6aGGGyKSefPnw803wzbbwOGHewH/DTfAd9/BQw8VVuIFfpI0YICfMbz2WtTRVNmtt3ri1bdvtIkXQJ8+fg761lvRxSASib/+1ReTHzIkI7+E8bh3EszlxAu89HDGDL8AIyL5T8mXSCZ9+CGcfrr/d//b32Drrb2GbMYMv+S6wQZRR5g5xx3n8zRuvz3qSKrk/vt9tOuoo7yxWtSDdt27Q6NG6nootcy4cd7h5pJLoE2btO9+zhzvWJ/LJYclNO9LpLAo+RJJtxUr4Kmn/D9mhw4+j+vkk+Hjj30U6IgjvByv0DVq5G3yR4yAzz6LOpqUPPUUnHWWJzyPPJIbZX5rr+0NMJ991huAiBS8FSt8kmXLll7/mwEvvujV0fmQfLVv738HlHyJFAYlXyLpMmcOXH+9r4p59NFeI3LbbV5aeO+93gWwtjn7bE/C7rwz6kgqNXKkL1HWubOPMjVoEHVEaxQVwfff+4oDIgVv0CBvSDR4MKy1VkYOEY/DFlvALrtkZPdpVa8e7LWXki+RQqHkS6Sm3n0XTjrJ/5NfeSW0betNNaZN83lPzZpFHWF0NtzQvzYPPwxz50YdTbneeMMTnHbt/FuXofO9auvVC+rXV9dDqQVmzoRrrvEhqQwtqrdkCYwa5YeIuqw4VbGYF08sWBB1JCJSU0q+RKpj+XLvQb7nntCxIzz3HJx5pvcufvllP1vOhZq1XHDRRbB0qU+gykHvv+/fri239G9dmrtZp0XTpnDAAZ58qUGtFLT+/b2+dtCgjB3i1Vc9AcuHksMSsZj/7qvxjkj+U/IlUhU//ABXX+1n6iec4Cvg3nWX14QNHuxtkeWPdtgBevb0jmVLl0YdzR98/jkcdJAnN6+84gN1uapPH/jqK+/hIlKQRozwyY1XXgmtWmXsMPE4rLMO7Ldfxg6Rdp06+ei3Sg9F8p+SL5HKhADjx8Mxx/gE8Ouugz32gJde8kYS/frBuutGHWVuGzDA58Q99ljUkfzum2+gWzeoUwdGj/aq0VzWu7cPpqrroRSkJUv8b+kOO/gi7RmyerWXFh98sC+zmC8aN4bdd1fyJVIIlHyJlGfpUvj3v/0/3j77eLJ1wQW+Rtfw4T5kUke/Qinp2tVntt9+e07Uzc2e7YnXwoU+96N166gjqtz660OXLio9lAJ1442+BMeQIRntdvPeezBrVn6VHJaIxXyK8ZIlUUciIjWhM0eR0r79Fi6/3NfmOu00WLbMuxV+/713L9xmm6gjzD8liy5/+qlnOxFasMDz5u+/9yqnfOh2VqKoCKZOhSlToo5EJI2mT/fk67jj4C9/yeih4nEfQe7RI6OHyYhYzLvwq+upSH5T8iUCPpQwZoyf3W61Fdx8M+y7r6/L9fHHvvhTkyZRR5nfjjkGNtkk0kWXFy3y6WdTpniPlL33jiyUajn8cM9j1fVQCkYIvh5go0Zw660ZP1w87stJNG+e8UOl3T77+O+/Sg9F8puSL6ndFi2C++7z4Y+uXT0Bu/RSL3959ll/LF96Eee6Bg18TseoUfDJJ1k//LJlvr7122/D44/DgQdmPYQa23hjPwFT8iUF45ln/G/C9df7xZkM+uorv5aWjyWH4KuWtGun5Esk3yn5ktppxgy45BIvLTzrLK9DefBBXxD5xhu9sYak31ln+SJaWR79WrkSjj/ez/Huv98HOPNVnz4webJXaonktYULvbV8hw5wzjkZP9zw4X6foeXDsiIW8/5PK1dGHYmIVJeSL6ldxozx/7zbbuvryBx0ELz5pi/2dNpp3lJKMqd5czjlFF8jbdasrBwyBM/5ios95zvttKwcNmOOOMLvNfolee+aa+DHH30NwHr1Mn64eBzatMmPBjvlicXgt9/go4+ijkREqkvJl9QeH3/sk7knToSBA+Hrr+GJJ9YU0kt29O/vs8aHDs34oULwrtUPPQRXXeXrPee7Lbbwdb2VfElemzzZL4D17euLWGXYggUwdmz+lhyWiMX8XqWHIvlLyZfUHk895UnWxx/DtdfCZptFHVHt1Lq1nwENHZrxnsnXXw933OErBFxzTUYPlVVFRd4y+5tvoo5EpBpWr/Yyw2bN4IYbsnLIl17yUr18T74228x7Qin5EslfSr6k9iguhv32g402ijoSGTAA5s+Hhx/O2CEGD/bRrpNP9gSskAY3S+asPftstHGIVMuwYT5x6ZZbstZ2MB6HDTfMyiBbxsVinnxpvT+R/KTkS2qHzz7zWz53WigksRjstptnRatXp333Dz/so12HHQYPPFB4a2Fvs4036FTpoeSd+fPhr3/1fu8nnZSVQ65Y4Wv69erlvZXyXSwGc+fCtGlRRyIi1VFgpyQi5Sg5Sz388GjjEGfmk7GmToWRI9O66+ef96Ya++/vLeWzMI8/EkVFPnjwww9RRyJSBZdf7hOwhg7N2lWRN96AX37J/5LDEpr3JZLflHxJ7VBc7Cvqbrpp1JFIiT59vNV/GtvOv/oqHH007L67J2GNGqVt1zmnTx8vO3ruuagjEUnR22/7Wg/9+8NOO2XtsPE4NGwI3bpl7ZAZtd12Xj2v5EskPyn5ksI3YwZ8+KFKDnNN/fpeG/jaa/79qaG334bevf3EZMQIWHvtNMSYw9q08ZtKDyUvrFzpTTY22wyuvjprhw3Bk68DDoAmTbJ22Iwy86pNJV8i+UnJlxS+krPTkgWSJHf07etZUg1Hvz7+GHr0gI039oWUszSHP3JFRd4+e+7cqCMRqcTQoX6R5c47YZ11snbYTz+Fr74qnJLDErGYv6/vv486EhGpKiVfUviKi725Q6tWUUcipTVtCqef7pOzqnkW8cUXcOCBvj726NGwySZpjjGHFRV5v5IXXog6EpEK/Pijr6140EFZr0CIx/2+V6+sHjbjNO9LJH8p+ZLCNnMmvPOOSg5z2QUXeAYxZEiVX/r99z6PY8UKeOWV2pdf77ILbL21Sg8lx118MSxfDnffnfU1H+Jx2GOPwpvuu8suXjSg5Esk/yj5ksJWshCSkq/ctfXW3oXy3nth0aKUXzZvnide8+f7Aqo77pjBGHOUmf9ov/oq/Pxz1NGIlOHVV31k+7LLYNtts3roWbP82lvv3lk9bFbUq+c9pJR8ieQfJV9S2IqLoV0778IguWvAAM8ehg1LafNff4Xu3X3Ow/Dh3t2wturTx0f+hg+POhKRUpYtg/PO84Xp/va3rB/+xRf9vtDme5WIxeCTT3ThRSTfKPmSwjVrFrz5pp+dSm7be2/Yc0+fjL9qVYWbLlniJ1MffghPPw377ZelGHPUHnvAFluo9FBy0G23+Vp+gwf7pMwsi8e9FLldu6wfOitiMe/m+NZbUUciIlWh5EsK1/PP+38mlRzmhwEDvHtGyeXqMqxYAUcdBePGwcMPF94k+uow80aeL78MCxdGHY1IwldfwXXX+d/f7t2zfvjFi30e6KGHZn2aWdZ07Ogrdqj0UCS/KPmSwlVc7OWGbdtGHYmk4vDDoWVLv1pehtWr4ZRTPDcbOhSOPTa74eWyoiKv8BoxIupIRPCLXv36Qd26cMcdkYQwejQsXVq4JYfgg4l77KHkSyTfKPmSwjR/Prz+up+VFuplz0JTrx5ceKGfSbz77h+eCgHOPx8eewxuuAHOPjuiGHPU3ntDixYqPZQcEY/D//4H11zjNbERhbDeerDvvpEcPmtiMXjvPS/HFpH8oORLClM87nOHVHKYX04/HdZd909Xy//v/+Cee3zO/mWXRRRbDqtb1wcOR4zwciuRyCxa5MtHtGvnF1MisHq1N6Dp3t3L8gpZLObl2O+8E3UkIpIqJV9SmIqLfab1rrtGHYlUxbrrQt++8NRTvkYbcPPNPtp11ll+L2Xr08fPe19+OepIpFa7/nr49lu/WhJR5jNxIsyZU9glhyX22ceLO1R6KJI/lHxJ4fn1V59pfcQRKjnMR/36+f1dd3HffT7adcwxvgazvp3l228/WH99lR5KhKZMgVtv9cmZnTtHFkY87lXMBx8cWQhZ07Qp7LSTki+RfKLkSwrPiy/C8uUqOcxXLVtCnz48OWQeZ58d6NHDOxvWrRt1YLmtXj1fTHb4cG++IZJVIfiaXuus48PVEYrHfa5Xs2aRhpE1sRhMmAArV0YdiYikQsmXFJ7iYth0U183SvLSiE5/54Ql9xHb+nuefrrw522kS1GRD/y++mrUkUit89hjMGaM1wZvuGFkYXz5JXz6ae0oOSwRi8Fvv/nahyKS+5R8SWFZtAhGjvTuA3X0452Pxo2Doiu2Z+cmMxi+ojtrNax40WVZY//9fdqcSg8lqxYsgIsv9oWnzjgj0lCGD/f7Qw6JNIysisX8XqWHIvkhkrNTMzvXzL4ys6VmNsnMYhVsO8zMQhm3RaW22y+xr6VmNsPM/tSMuirHlTw1cqT33FXJYV6aNMkXTm7VCl66+wvW/fYTeO65qMPKGw0b+knn8897BzSRrLjySpg71xfgi7g+OB73Rotbbx1pGFm16ab+fpV8ieSHrCdfZnY0MAj4J9ABGA+MNLMty3nJhcAmpW4zgKeS9rkVMCKxrw7ADcBgMytK2qaqx5V8VFwMG2yw5lKg5I3PP/cJ8s2be7+UDU88GLbZBm6/PerQ8kqfPvDTTzB2bNSRSK0waZInXeeeC7vtFmkoP//sI+e1qeSwRCwGb77pU+9EJLdFMfI1ABgWQrg/hPBZCKEf8CNwTlkbhxB+CSHMKrkB2wBbA/cnbXY28EMIoV9in/cD/wEuqe5xJQ8tXerNNg47zLsPSN74+ms44AC/aP7KK7D55vgn/fv7TPIJE6IOMW8cdBA0aaLSQ8mCVavgnHN8jtd110UdDSNHeki1NfmaOxemTo06EhGpTFaTLzNrAOwGjCr11Chg7xR30xf4NIQwPumxvcrY58vA7mZWP03HlVz3yis+67hPn6gjkSqYNQu6dfPpeqNGQevWSU+ecor3Ui616LKUr3Fj6NHDqzVXabqcZNL998O778Jtt/nvacTicWjRAvbYI+pIsk/zvkTyR7ZHvjYA6gKzSz0+G9i4sheb2XrAUfxx1IvEa8vaZ73EMat8XDM708zeM7P3Vqp/a34oLvYTgK5do45EUvTzzz5S88MPMGIE7LxzqQ3WXttXVy4uhq++iiTGfFRUBLNnw/jxlW8rUi1z5sDll0OXLnDccVFHw/LlPvJ1yCG1s9dS69aw0UZKvkTyQb79iToBj/mRTB8ohHBfCGH3EMLu9VTClvtWrPDLnoceCg0aRB2NpGDRIujZ0+d6Pf887LVXORuef76fTd11V1bjy2c9enjzDZUeSsb89a9eaTB0aE6sfj52rC+zUBtLDsG/BbGYki+RfJDt5GsesApoUerxFsCsFF7fFygOIfxU6vFZ5exzZeKYNT2u5LrXX/dhFHU5zAvLlvlqAO+8A48/7mWH5dp8czjmGHjgAfjll6zFmM/WWcdHFIuLYfXqqKORgjNuHPznP3DJJdCmTdTRAH7trXFjX26htorFfP7sd99FHYmIVCSryVcIYTkwCSh9qtUN7z5YLjPrCOzCn0sOASaUs8/3QggranJcyRPFxV6iduCBUUcilVi50quUXnkFHnwQjjgihRdddJFfZX/ggYzHVyj69PGTsHffjToSKSgrVnhnw5YtvcV8DgjBk69u3WCttaKOJjqa9yWSH6IoO7wdOMXMzjCzNmY2CNgUuBfAzB42s4fLeN2ZwPQQwpgynrsX2MzM7kzs8wzgFODWVI8reWzVKq9b69kTGjWKOhqpwOrV0LcvPPss3Hmn99NIya67+tySQYO0gFWKDjkE6tdX6aGk2aBB8OmnXgacI5nO5Mnw7be1t+SwxC67+Ki3ki+R3Jb15CuE8CTQHxgIfAh0BnqEEL5JbLJl4vY7M1sHOAYo87J3COEroAewb2Kf/wdcEEIoTtqmsuNKvnrzTZ/8rZLDnBYCXHwxDBsG11wDF15YxR0MGAAzZyqbSFHTpl6CVVystX8kTWbO9F/eQw7JqUwnHvc5T716RR1JtOrWhb33VvIlkusiabgRQhgaQmgVQmgYQtgthDAu6bkuIYQupbZfGEJYO4RwcwX7HBtC2DWxz61CCH8a0arouJLHiot9xKt796gjkQpcd52Pdl14IVx1VTV20LMnbLedt7VWNpGSoiKYMQM++ijqSKQgXHSRD18PGhR1JH8Qj0OnTt5mvraLxeCTT3yhdZF8ZmbnmtlXZrbUzCaZWayS7c8zs8/MbImZTTWzk8rYpsjMppjZssT94Zl7B+XLt26HIn+0erUnXwcf7HO+JCcNGgRXX+1lhrffXs3maHXq+Mnfe+/BW2+lO8SC1Lu3f9k0WCg1NnKk/yANHAhbbRV1NL/7/nv/k5BDA3GRKpn3pT+Rks/M7GhgEPBPoAPen2GkmW1ZzvbnADcB1wJtgauBIWZ2SNI2ewFPAo8C7RP3T5tZpwy+lTJZ0BXkSjVp0iQsWrQo6jCkLBMmeJ3FI4/ACSdEHY2UYdgwOPVUb6zx5JNQo5UbFi+GLbaAfff1VYSlUn/5iy9kPWVK1JFI3lqyBNq180mEH33k6xjkiH/9C84+20d72raNOproLV0K663nFQY3l1srJBItM1scQmhSwfPvAJNDCH2THpsOPBNCuLyM7ccD74QQLkp67DagUwihc+LzJ4HmIYRuSduMBuaGEI5Nx/tKlUa+JL8VF/sJQW0v9s9Rzz4Lp5/uXcgee6yGiRf4BP9zzoEXXoAvvkhLjIWuTx/47DMlX1IDN97o9atDhuRU4gVecrj11rDjjlFHkhsaNYI99tC8L8lfZtYA2A0YVeqpUcDe5bysIbC01GNLgI5mVj/x+V5l7PPlCvaZMVo9OAXNmzdnzJgxUYchZWnZ0hf5/PDDqCORUiZNasbll+/EDjss5KKLJjNhwqr07LhLF2je3Ec9taBNpVq0aIDZXtx669ecdJL6C0kVLVvmQykPPeQdHXLof+GSJXV55ZV96N37e8aO/TLqcHJGy5Zb8eSTW/DSS2/SqJEW+pOcVM/M3kv6/L4Qwn2JjzcA6gKzS71mNnBAOft7GTjdzJ4F3sOTtzOA+on9/QhsXM4+N67um6guJV8p+Omnn+jSpUvUYUhp778PF1zgaz/p+5NTJkzwOV477ABjx65Hs2YVzpOtukcfhaee8uSrWbP07rsA7b03vP/+Vjz0UO7M1ZE8EILPp50wAaZOhU02iTqiP3juuZJlx7agS5ctog4nZyxe7JUGDRvuq3+NkqtWhhB2T+P+rsOTqPGA4UnVf4C/Ajl3BUJlh5K/iov9Smzv3lFHIkkmT4YePfw8bdSoDOVGF13kZxj/+lcGdl54iop8qs6XGhyQqnjmGf8lvv76nEu8wEsOmzaFzp2jjiS37L23NzVS6aHkqXnAKqB0/9IWwKyyXhBCWBJCOA1YC2iFL1n1NbAQmJvYbFZV9plJSr4kP4XgyVeXLrDBBlFHIwlffAEHHghNmsArr8DGmRrM33lnn0g2eDAsX56hgxSOI47we3U9lJQtXAj9+0P79nDuuVFH8yerVsGLL/qFnvr1K9++Nmna1P9EKvmSfBRCWA5MArqVeqobPrJV0WtXhBC+CyGswtcHfjGEUDLyNaE6+8wElR1KfpoyxctgqrBS7/Llvr7UypU+Zajk1qzZHz9fd91qtkKv5b77Dg44wE+KXn8dWrXK8AEHDPC13Z56Sp0uK9GyJey+uydff/1r1NFIXrjmGvjhB/+hqXGnnPR7+22YN08t5ssTi8G//+3/73Lw2ydSmduBR8xsIvAWcDawKXAvgJk9DBBCOCnx+XZAJ+BtoBkwAGgHnJy0z0HAODO7DHgeOBzoCmR97Fy/kpKfios9Qzo89fXxnnoKbrrJu0EtLd0TJ0ndun9OyFK5NW3qr62N5s71gaiffvLEq02bLBz0oIO8xdntt8PxxytjrkSfPnDZZfDtt7BlmSuliCRMnuyL8/XtC3vuGXU0ZYrHPak4+OCoI8lNsRjcfTd88IF3PxTJJyGEJ81sfWAgsAnwCdAjhFDSNar0f7G6eMK1PbACeB3YO4TwddI+x5vZMcD1+HpgXwJHhxDeyeR7KYvW+UqB1vnKQbvs4kNUVair2HNPWLDA224vWwY//+zJQkW30tv88kvFx2jatOzErLJkrkGDGn49IvTrr76W1Kefwssv+xJcWfPAA36C+Npr0LVrFg+cf774Alq3hjvu8GoykTKtXu1n7tOmweefw/rrRx1Rmdq0gc039/Jm+bMff4RNN4XbbvMiAZFcUtk6X4UuteTLrCEhLMt8OLlJyVeOqcZZ5LvvQseOPkXo/POrf+iVKz2BqyxpKyuJW11Bv50mTao+0ta8OTRuHO2Az5IlfuV5/HhfeqtHjywHsHSpD+N06gTDh2f54PmnGtcspLZ56CFfnO+hh3x19Bw0bRpsvz3cdRf06xd1NLlr221hp520Hr3kntqefKVadvgDZo8CDxDC5EwGJFKpkq4BJV0EUjBkCKy9Npx0Us0OXa+e9/eoao+P1at9/nqqydpnn635uKJ+Eg0bpjayVvqWjnltK1bAkUf6ifxjj0WQeIHXkJ53ns9PmTrVz8ikXEVF/qWaNSuDzVAkf82f75MC99kHTj658u0jUnKd5ZBDoo0j18Vi3pQkBFVli+SSVEe+VgMlG04C7gceJ4TfMhda7tDIV47p2NHvJ05MafN58/D5ML0AACAASURBVLw85fTTPQnLJyF4R/XKyiHLulX0I1uVeW3J2zVt6gnoqlXe4+KJJ7zb+5lnZu9r8idz5vjo16mnwj33RBhI7vv0U2jXztclP+ecqKORnHPGGTBsmE8U2mmnqKMp1377eQXCRx9FHUluKxnEnDIlS/NwRVKkka/UvA/smvh4d3zl6NsxexJ4kBAmZCI4kT/55huvIbzxxpRf8uCDPsfrvPMyGFeGmHlJYpMmsEUV1xBNdV7bTz95/vL55/7xggUV73e99WCttXxOwU03RZx4AWy0EZx4op80Xnedlh6owI47+uBgcbGSLynlrbf8j+Ull+R04jV/Prz5JlxxRdSR5L5YYm37N95Q8iWSS1JvuGG2Ld4z/2igbeLRkhd/BtyDJ2IV9JHLTxr5yiF33OGzh6dP94L2SqxaBVtv7Zu++moW4isAK1d6Y5GKkrX5830hz5xZ/mfKFGjb1pOvgQOjjianDRzo1y5mzVKeKgkrVsCuu/ov/pQpXqOdox55xMvHJ05UF7/KhOBrY3fr5l83kVxR20e+qtft0KwdMBjYL/FIyU5mAj0IYUpaossRSr5ySOfOPnkqxXqTF16Aww7zK/1VmCIm+ahHD3j/fR8dbdgw6mhy1gcf+Hn2Aw94SZIIt94Kl17qnRkOOyzqaCp05JE+SPfdd1CnTtTR5L4jj/Rika+/jjoSkTVqe/JVtT9dZuti1g94AtiXNUnXcmA13nc/z2bVSN748Udvq1dUlPJL7r7b53tpIc5aYMAAmD0bHn886khyWvv2sNVWa/rWSC03c6Z3YenVC3r3jjqaCi1bBi+95I02lHilJhbz61EzZ0YdiYiUSO3Pl9kemD0I/ADcCewIGDAHuBrYAtgFT8I6ZiRSkeee8zqKFJOvzz+H0aN9bks9LSde+PbfH3be2Rdd1vqF5TLzX6HRoyuf3ye1wIUXejvWwYNzviXemDHw22+6mFYVyfO+RCQ3pHrt6B3gFGAtPOn6IPH5loRwHSHMS5Qafgs0ykCcIn6pfocdvGtACoYO9cWLzzgjw3FJbjDz0a+PP/bMQspVVOTTfF58MepIJFIvvugXta68Elq1ijqaSsXj3uxn//2jjiR/7Lyz1vYTyTVVaTW/GhgO3EEI48rZ7jBgPUL4TxpjjJzmfOWAefN8YaLLLoPrr69084ULYbPNvIpGE41rkWXL/CSyfXsYOTLqaHLW6tXenX+PPbQAa621eLE3qWncGD780K9U5bAQ1vzMPvts1NHkl+7dvezwk0+ijkTEac5XagYBrQnh8HITL4AQni+0xEtyxAsveOvCFEsOH3nEE7Dzz89wXJJbGjb0b/pLL/miVlKmOnX8V+mll7yMS2qh66/3Lgz33JPziRd4fvjddyo5rI5YzP8czp8fdSQiAqkmXyFcRAhfZTgWkfIVF3uXgPbtK900BF9Meffd16zHLLXI2Wf71fw77og6kpxWVARLl8KIEVFHIln32Wfe4fCkk3zF4jwQj3tlcc+eUUeSf0rmfb31VrRxiIhLteHGLZjNwOySUo9fknj85kwEJwJ4V4DRo/1sMYUJ4WPG+FI155+f8/PHJRPWXx9OOQX++1/vfihl2mcfX59aXQ9rmRC8C9Haa8Mtt0QdTcricV9bcMMNo44k/+yxhw9uat6XSG5IteywN9ASKD09Ow60SjwvkhkvvujdAVIsObz7bj//PvroDMcluat/f5//dc89UUeSs+rWhcMPh//9D5YsiToayZpHHoGxY32l7Y02ijqalHz3nS/hp5LD6mnUyKtAlHyJ5IZUk6/NE/dfl3r828T9FmmJRqQsxcXePSOFGsKZM+H5573DYSP13ay9ttvOFwMaOlSZRQWKimDRIhg1KupIJCt++gkuuQT23DOv2sAOH+73Sr6qLxaDSZP8911EopVq8rUycb9Tqcd3KvW8SHr99pt3BTjiiJRW1fzXv/z+7LMzHJfkvgEDYO5cLz+UMnXpAs2aqfSw1rjiCu+6cM89ebVKcTwOrVvD9ttHHUn+isVg5Up4552oIxGRVP/6Tk3cP4RZZ8zWx6wz8EDi8c/TH5oI3g1g6dKUSg6XLYP77vMBjzxYskYybb/9YNddvfHG6tVRR5OT6teHww7zk9vly6OORjLq7bf9D+QFF6TUuChXLFwIr73mo16aw1t9e+/tXz+VHopEL9Xk6wl8ceUdgbHAnMT9TkBIPC+SfsXFPi+hc+dKN336aR/oOO+8LMQlua9k0eXPPoOXX446mpxVVAS//AKvvhp1JJIxK1d6OcAmm8C110YdTZWMGuUXBlRyWDPrrQe77KLkSyQXpJp83QWMxxOw5BvAW4nnRdJryRLvBnDYYd4doBJ33+1lKfvvn4XYJD8ceaTPF7z99qgjyVkHHADrrqvSw4J2993w0UcwaBCss07U0VRJPA7Nm/vIjdRMLAYTJnj/KhGJTqrrfK0A9gcuw5OtLxL3fwO6EYLmfEn6jRrls4NTKDl87z2vZT/vvLyayiCZ1qAB9OvnSxV89FHU0eSkhg2hVy9vVLNSf8kLz/ffw5VXwsEHp9wxNlesXOnX33r2hHr1oo4m/8VisHixd44UkeikfpoawjJCuJkQYoSwXeL+FkJYlsH4pDYrLvZuAF27VrrpkCG+bM3JJ2chLskvZ54JTZpo0eUKFBV5H4Zx46KORNLuoos8i7n77rybNDVhgv9cquQwPUoWW1bpoUi0qjZGYNYUsz0w2/dPN5F0Wr7c60169/auABWYNw8efxxOPNHLp0T+oFkzOO00eOwx+PHHqKPJSQcfDP/P3n2HR1llDxz/ntCkiohSRYodFRWVOqiLFBEEHFTErohSbLira9m1rLK7NkQIRVfB/kMJ6CBdBZWiFEVUkC5SBETpnXB/f5wJhpgyCcncKefzPHlG3nln5gTJZM57zz2nTBkrPUw4EyfqZtiHH4Z69XxHk2+hkC5et2njO5LEULUqnHSSJV/G+BZZ8iVSApFXgV+BL4GpWb4+LaoATZL69FPtAhBBmcyrr2qnQ2u0YXJ0zz169T811XckMalMGWjXDkaPtsaQCWP3bn1TPOUUeOAB39EUSCikhQ9xtk0tpgUCMH26/Zwb41OkK19/BW4BivHnphuZm28YUzjS0vQ3bqtWuZ6Wnq4jay65BOrXj1JsJv7Uq6eNW4YMsSmjOQgGYf16mDnTdySmUPz737Bihf6bL1XKdzT5tngxLFliJYeFLRDQWduLFvmOxJjkFWny1RVtKT8//GcHjAb2oM03Xi/80EzSOnBAd/+3b5/nh4Zx42DVKujTJ0qxmfh1//36qeONN3xHEpMuv1x/3Kz0MAEsWQL//S906wZ/+YvvaArkww/1tkMHv3EkGtv3ZYx/4pyL4CzZAZQGTkaTLYdzxRC5HPgAuBrnxhRloD6VLVvW7bSr5dEzdap+YBg1Ks+yw9at9QreypXWDcvkwTlo3Bg2b4Yff7S2mNm44gptCvnTT3HXm8FkcE4rBubO1X/nVav6jqhAmje3znxFwTmoXl1/xb79tu9oTLISkV3OubK+4/Al0k8fGR0PVgHpAIiUBj5GSxGfKPTITPJKS4PSpbULQC4WL4YpU3R2qCVeJk8ZQ5eXLtUlU/MnwSD8/LN+bjdx6t13dWJ2v35xm3j9+quWv1rJYeET0dUvW/kyxp9Ik6/N4dvSwO/h//4HcH/4v08qzKBMEjt4UHf9X3aZtgfPxeDB2gnr9tujFJuJf8Eg1KoFzz/vO5KYdMUVeiHDSg/j1JYteoHh/PPhjjt8R1Ng48bpCo0lX0UjEIDVq7Vk3xiTPyKICEd0ZSvS5GtF+LYG8DXaYONB4F/o/q+VRxKEMYfMmqXtwPMoN9y+HUaMgKuvhuOPj05oJgEUL66dDz/7DObN8x1NzDnmGGjZUit+I6lINzHm0Ud12WjoUChWzHc0BRYKQY0acO65viNJTLbvy5iCcw7HEXZ5jzT5mgIsAU4DngMOcniXwyePJAhjDklL0+Ws9u1zPe2tt2DbNmu0YQrgttu0k6YNXc5WMAjLl8OCBb4jMfkyd66WA/TqBQ0b+o6mwPbsgUmTdNXL9h0WjbPO0pmYlnwZU2DLRCjwEIzIGm786VHSFLgKOAB8gHMzChpAPLCGG1HiHNSpA2eeCR99lOtpZ56p28LmzLFf0KYA+vaFgQO1U0vNmr6jiSm//qpbhR55BJ60y2rxIT0dGjWCtWu1ycbRR/uOqMDGj9fOmxMm5Lnt1xyBdu20sc7Chb4jMcko3htuiPAmcAJwt3Pk+1Jl3itfIqUQeQ2RVxGpB4BzM3HuPpz7W0ESLxHpJSIrRWSPiMwTkUAe55cUkSfDj9krIj+LyN2Z7p8mIi6brx8ynXNzDuccld/4TRGZN0+L0PMoOZw2TX9h9OljiZcpoLvv1v2FAwf6jiTmHHcctGhh+77iypAh+v7Zv39cJ16gJYflyunsRlN0AgHtFLxpk+9IjIlLK4AdwCQRNoowToTHI31w3smXc3vROV83A+sKFuMfROQaYADQDzgXmAlMEJFauTzs/4C2QA/gVHTVLXOmeSVQLdNXbWA78F6W59mV5bxqzrk9R/YdmUKTlqb7FPLYZZ2aCsceC9dcE6W4TOKpXRu6dIFhw2DHDt/RxJxgUC9w/Pij70hMnn75RZcpL7007t8UDx6EsWOhTZu4nAsdVzL2fU2f7jcOY+KJCMcCOMdjztHeOaqhucww/tiKladI93xlDFc+Ll9RZq8vMMI594pzbpFz7i7gF6BndieLSGugJdDOOTfFOfeTc+4r59y0jHOcc78759ZnfAHNgTLAa1mezmU+L3yuiQXOafJ1ySWaWeVg9Wqdv9y9u5YdGlNgffvC1q0wfLjvSGJO5856a6tfceD++3WjVGpq3JcCfP01rFtnXQ6j4YILNMG1fV/G5MsSEVaIMFKE+0VoAWx1jpBzPBbpk0SafD0A7AWGIlKlINGClg8CDYHJWe6aDDTN4WGdgDlAXxFZIyJLReQlESmXy0vdDkx0zq3Ocry0iKwKP89HIpJjLyUR6SEic0Vk7oEDB3L/xsyR+/57nb/UpUuupw0bpldH77wzSnGZxNWoETRtCi++qHtmzCE1auhfzahRviMxufr4Y53r9fe/wymn+I7miIVCOvu8XTvfkSS+UqXgwgst+TImP5zjWKAN8C3wKPAy8KsIP4gQ8ZXcSJOvN9Dhym2AdYj8gsiKTF/LI3yeyuhQ5g1Zjm+AHHvm10VXshoAQaAPWoI4IruTReQU4CLglSx3LQZuBToC1wJ7gBkicnJ2z+Oce9k5d75z7vziNsG36KWl6VXbTp1yPGXvXnj5ZejQQavGjDliffvCihXw4Ye+I4k5wSDMn69/PSYG7dmjnQ3r1YOHHvIdTaEIhaBZM6hc2XckySEQ0NVGq7w2JnLOsRTNQ052jtOAE4EfgAqRPkekyVdttIwPtKaxSvhY5q+ikoLOEusWLjechCZgQcl+Fe52tIxxXOaDzrlZzrnXnXPznXNfANcAy4G7ijB2E6m0NP1NUCXnhdVRo7QTm7WXN4WmUyftsPnCC74jiTlXXqm3VnoYo555RqsFBg+Go+K/b9SqVfDtt1ZyGE2BgC76f/ml70iMiTuVnGMTgHNsBK5Dc6OIRJp8/Zzpa1U2Xz9H+Dyb0BW0rAFWAXLaf/ULsNY5tzXTsUXh28OadITLGm8Chjvncq0VdM6lA3OBbFe+TBQtWaJlh3l0ORw0CE49VYfAGlMoihWDe++FGTPgq698RxNTatfWcVGWfMWgZcugXz+dMt+6te9oCsXYsXpryVf0NG2qZZ5WemhMvs0V4e5Mfz4IHB/pgyNLvpyrjXN1cv2K6GncPmAe0CrLXa3QrofZmQFUz7LHK6O4fVWWczuhpY2v5hWLiAhwNprcGZ8yPt1lXGrPxty5enWuVy/9ZWFMobnlFm3PbUOX/yQY1Jx0zRrfkZhDnIPevXUYfQL9mw2F9OJaAmxdixsVKkCDBpZ8GRMpEZqF//MeoIMI34gwDJjOHwtDefLxMfYF4GYR6S4ip4vIAKA6MBRARN4QkTcynf8O8BswXETqi0gztFX9KOfcxizP3QP4xDn3p10KIvKYiLQRkboicg6aoJ2d8brGo1GjtPlBLsNuU1OhbFm46aYoxmWSQ/ny0KOH/jtclfV6TnLLWIwePdpvHCaT99+HyZPhqaegenXf0RSKrVt1fqOtekVfIKAXNvft8x2JMXFhQPi2u3O0QpOwxcBg4OpInySy5Evkxjy/IuScGwnci3YJmY8202jnnMv41FOLTOWEzrkdwKXA0WjXw/eAz9DmGZlClLrAX/hzo40MFdGuJIvQ7oo1gBbOudmRxm6KwMqVuuM3l5LD337Thl433hj380NNrLr7bm348tJLviOJKaecAmedZV0PY8a2bVome+65WgaQICZNgv37LfnyIRCA3bv117AxJk8lRKiL7vHCOT53jhec403n2Bvpk0Taxm8E2vQiJw7tiBgR59xgNEvM7r6Lszm2GMi1sD282pVjMumcuw+4L9IYTZRkXFLPJfl69VXtdNi7d5RiMsmnZk3dP/PKK/DYY1qPYwD90XziCVi/Hqrm1JPWRMc//6n/Iz74ABKoC28opOMdmzTxHUnyyRi2/MUX0Lix31iMiQNPA18AR4swGu0dMReY5xy/Rfok+Sk7lDy+jMm/tDQ45xyoWzfbu9PTtZnXxRdD/frRDc0kmfvug+3bNds3hwSDus3ogw98R5LkvvkGBg6EO+7QAU0JYv9+GDcO2rfX/jcmuqpUgZNPtn1fxuRE5I+FKud4D6gJrAHeBsoDfwUWi7Ay0ueMNPm6JcvX7cC/gY3ATrT1uzH5s3YtzJqV66rXuHG6Dcfay5sid/750KIFDBgANlj9kPr1tfzQuh56lJ6uk+UrV9YuhwlkxgzYssVKDn0KBGD6dDh40HckxsSkBSJckvEH53BAY+dIc46HnKO1c1RGtz5FJNJuh69n+XoV5x4BAuj8r4i6HRpzmDFj9DaX5Cs1VSvCOnaMUkwmud1/v2b71mHiEBH9EZ06VfdfGg9eeQVmz4bnn4djjvEdTaEKhbRxY4J0zI9LgQBs3gwLF/qOxJiY9B3wsQjvilAdwDm2ZD3JucJf+crJMmAX4Y1nxuRLWhqcfrp+ZWPxYm3qdeedCbW9wcSy9u3hpJP0Q67LbZtrcgkGdfElFPIdSRLasAEeegguuQSuS6xftc7pv6mWLaFcubzPN0Uj874vY8zhnOMatO9EA2CRCH1FOKIi6SPpdtgD+AAoC9jbpsmfX3+Fzz/PddVr8GAoUQK6d49iXCa5paTo3q/Zs7Uk1gBw3nk6dNm6Hnrwt7/Bzp36hiiJtb160SJYvtxKDn2rWxeqVbPky5icOMcn6HiqfsATwHwRWhT0+SJd+RoBDM/yNQRoj3Y6tHbtJn8++EALzLt0yfbuHTtgxAhtQFelSnRDM0nuppu0tOv5531HEjMySg+nTNGZTCZKpk6FN9/UBOy003xHU+gyVlI7dPAbR7IT0dWvL76wBX9jcuIcB5zjv8BpwI/AVBHeEiHfn1ILo9vhcsCagJv8SUuDevXg7LOzvfutt3SkjTXaMFFXtiz07Kl7Epcv9x1NzAgGtTPdRx/5jiRJ7Nuns7zq1IFHHvEdTZEIhbTPTY0aviMxgQCsWWNz5o3JjQjHACcCE4F5QDdghQjTRRggQkRzjwva7fCW8As2A07HuSX5jN8ks82b4ZNP9NNcNmU0zsGgQdCwITRq5CE+Y3r31o2GNnT5kEaNoHp163oYNc89Bz/+qG+GZcr4jqbQbdgAX35pJYexwvZ9GZM9ES4T4WMR1gObgOnAUKAC8CE6t3gN0A54LZLnjKyNgXOvFyRgY7I1dqy28s5hv9dnn8EPP8BrryXcFgcTL6pXh2uv1ZlfTzwBFSv6jsi7lBS48kr9K9m5UxcITRFZuRL+9S/9C2/Xznc0RWLcOL3QZslXbDjzTDj6aE2+brjBdzTGxJThwGZgELAQLTlc6hz7s54oQoVInjDShht1EGmByOlZjp8ePm6t5k3kRo2CE06ACy7I9u5Bg6BSJejaNcpxGZNZ376aZbz8su9IYkYwCLt3w4QJviNJYM5pvXWxYvDii76jKTKhENSqlWPluYmyYsWgWTNb+TImG18ANzrHU84x2jkWZpd4ATjHtkieMNKyw1RgKnBhluPnh48PivB5TLLbvl37x195ZbbLWmvWaC+O7t2hdGkP8RmToUED7YH90ku62ckQCMBxx1nXwyI1ZgyMHw9PPqkXqRLQ7t36a+CKK6y6IZYEAlrp+uuvviMxJnY4x1XOMacwnzPS5Ou88G3W650T0aYb52FMJMaNg717cyw5HDZMmyD27BnluIzJTt++sHYtvP++70hiQrFi0Lmz/hjv2eM7mgS0Ywfcc48uB919t+9oiswnn2gCZiWHsSVj39f06X7jMCbRRZp8HRO+zfrrdl/4tlLhhGMSXlqa9o5v2vRPd+3dqxVe7dvrTCFjvGvbVlt829DlQ4JBzREmT/YdSQJ6/HFd/h8yJKEny4dCUL48XHSR70hMZuefD6VKWemhMUUt0uRrc/j2qizHg1nuNyZnu3ZpOU3nznoJPYtRo2DjRmsvb2JIxtDlr7/WoeCGSy7RMWjW9bCQLVige7y6d8/24lSiOHhQey5ddhmULOk7GpNZqVLa1dSSL2OKVqTJ15doeeFgRF5F5H5E/ocOWnbh+43J3aRJmoDlUHKYmgqnnAKXXhrluIzJzQ03QOXK8MILviOJCSVKaLlYKKSjqEwhOHgQ7rxTs9r//Md3NEVq7lxYv95KDmNVIADffKOr28aYohFp8jUATbKKAzcDz6CzvkqEj/cviuBMgklL0zaG2dSazJsHs2bpeKWU/Iz+NqaolS6tw27HjoUlNtIQ9PrJli0wdarvSBLEa6/pG+Czz8Kxx/qOpkiFQlr4cNllviMx2QkEID1d/zkaY4pGZB9znZsK3AvsR1fAMr72Affh3GdFFaBJEHv36ofXjh310nkWqak6N+immzzEZkxeevXSf7cDBviOJCa0agXlylnXw0KxaRM8+KB+6k2CN8BQSL/VSrZTPCY1aaIXQK300JiiE/kag3MDgXrA7cCj4dt64ePG5O6TT2DbtmxLDn/7Dd59V6u7jj7aQ2zG5KVKFbj+ehg+XP/BJrmjjoIOHXQsxIEDvqOJcw88oO+NQ4YkfN/1lSvhu++s5DCWVagA55xjyZcxRSl/BV7OrcW5V3GuX/h2bRHFZRJNWpq+q2ezoeu117Rtde/eHuIyJlJ9+2p/7GHDfEcSE4JBXbSxD2lH4IsvNKHv2xfq1/cdTZEbO1ZvLfmKbYEAfPml7ek0pqhElnyJ/A2RTxHpmeV4z/Dx+4siOJMgDhyADz/US+WlSh12V3o6DB4MF18MZ57pJzxjIlK/PrRpAwMHahltkmvbVrfDWdfDAtq/Xwca1qoF//yn72iiIhSCM86AevV8R2JyEwjoBdF583xHYkxiinTl6ybgIv7c1XAGcDHafMOY7H32mZZqZVNyOH48/PSTtZc3caJvX23VNnKk70i8K1tWmyaMHq3N+kw+9e8PP/ygyXzZsr6jKXJbtuivAlv1in3Nm+utrWobUzQiTb5qh28XZTme0frrxEKJxiSmUaOgTBldNchi0CCoUUP7cBgT81q10iVaG7oM6PWUX37REiWTD6tWwRNPaCaSJNnIhAlaBJEk325cq1JFx75Y8mV8EpFeIrJSRPaIyDwRCeRxfjcRmS8iu0RkvYi8JSJVs5xzj4j8KCK7RWSNiKSKSLmi/U7+LNLkK2MXcJ0sx+vm83lMsklPhzFjoF07TcAyWbIEJk/W8TbFi3uKz5j8ENHVrwUL4NNPfUfjXfv2OijXuh7m0z336O1LL/mNI4pCITj+eLjwQt+RmEgEAjBjhq1qGz9E5Bp0zFU/4FxgJjBBRGrlcH4z4E3gdaA+0Ak4A3g70znd0FFZTwOnAzcC7cKvE1WRJk3Lw7dDEKkJEL5NzXK/MYebORM2bMi25HDwYO3effvtHuIypqC6ddNLwzZ0mQoVoHVrLT20hcAIhUK6B/axx+DE5Cga2bdPV77at9cZXyb2BQKwebNWxhrjQV9ghHPuFefcIufcXcAvQM8czm8CrHHO9XfOrXTOfQkMBBplOqcp8KVz7k3n3E/OuU+BN7KcExWRJl8foKtfAWAVItuBVUALdMjy6KIJz8S9tDRtsnH55Ycd3rFDm3xdfbV+jjUmbpQqpa05x4+HRVkrsZNPMKhVdLY5PwI7d8Jdd2nzlvvu8x1N1HzxBWzdaiWH8SQQLvCy0kMTbSJSEmgITM5y12Q0gcrODKCaiHQQVRnoCozPdM504BwRaRx+nVrAFVnOiYpIi72eAa4GTgn/OfPu4MXAc4UZVKypVKkS06ZN8x1GfKpXTzd2ZflkFgpVZ9u2U2jS5GumTdvmKThjCqhJE933NXu2ruwmsUqVilOsWFP691/N7bev9B1ObFu7Fu6+G049VWu6ksTgwSdRsmQ1SpacwbRpVscWD5yDypWbkJa2hTPOsItMptAVF5G5mf78snPu5fB/VwaKAVl/uW4A/jyvCHDOzRKRrmiZYWk0v5mCNgzMOOf/RORY4HMRkfA5bwIPFsL3ky/iIq0V0YD/BXQAqqB/CR8C/wQq4NxPRROif2XLlnU7d+70HUb8mT0bGjWCESPgpkP//nEOzjpLFxDmzk34uaImUd15p/7bXr0ajjvOdzRetW6tXUsXL7af5xz98INOr80Y1p0knIO6dbVPTcacLxMfunaF6dP1Lc5+rk1hEpFdzrls27yKSHVgLXCRc+7zTMf/CVznnDs1m8ecgSZbLwKTgGrAs8B859yN4XMuAkYCjwJfASeh+71Gjrz/8wAAIABJREFUOOeiOu8j8kYZzv2Gc71w7gScKwmcDXyPJmDLiig+E8/S0rSTRpZak88/188hffrYG7qJY/feq/O+hgzxHYl3wSAsXQrff+87khjlnM70qlABnnnGdzRR9f33mphbyWH8CQR0sfann3xHYpLMJiAdXejJrAqwPofHPATMds4965xb4JybBPQCbpCMXhXwFPCuc+5/zrnvnHNjgIeBB0Qkqm3f8telUKQEIlciMhpYhzbcaMYf3RCNUc5p8vWXv8Axxxx216BBUKmSXlUzJm6ddpruZUxN1YmkSaxTJ72QYgOXc/D667p55r//TbpV0lBIb9u39xuHyT/b92V8cM7tA+YBrbLc1QrtepidMmjCllnGn1PyOCfqOUxkyZdIAJFhaMb5PtARKMUfAa8tkuhM/FqwAJYv/1OXwzVrtPP8bbdB6dKeYjOmsPTtCxs3wttv531uAqtSBVq0sJbz2frtN/jb33Sf4K23+o4m6kIhbS9frZrvSEx+nXkmVKxoyZfx4gXgZhHpLiKni8gAoDowFEBE3hCRNzKdPxboKCI9RaRuuPX8S8DXzrmfM53TQ0S6ikgdEWmFbqf6yDl3IGrfGbklXyKnIvIUIiuAaUB34Bg04cpIuhzQGhuybLJKS4OUFL0knsmwYTo3pGdOzUKNiSeXXKL7eF54Iel7rQeDWk68eLHvSGLMQw9pz+6hQ/U9MYn88otu/bWSw/iUkgLNmlnyZaLPOTcSuBfdnzUfaA60c86tCp9SK/yVcf4ItD19H3RL1ChgCbpYlOEp4Hk04VoIvIZ2UOxehN9KtnJuuCFyEE2uMi/HbUEzx2/RDocO5xJ+aoc13CiA+vV1oubUqYcO7d0LtWppD46MUhRj4t6bb8KNN8LEidCmje9ovFm7FmrWhKefhocf9h1NjJg5Uz+99u2r3TGTzCuvQI8eWghx1lm+ozEF8d//wt//rk1djz/edzQmUeTWcCMZRHIZzgHvAm2B43HuJrSTiDHZW7QIFi78U8lhWppWaPXp4ykuY4rCNddoTVWSD12uUQMaN7Z9X4ccOKBL/DVrwuOP+47Gi1AIatfW8jUTnzL2fU2f7jcOYxJJpDUQHYEeQBCRckUYj0kEGZ++Onc+7PCgQXDyyXBptlMajIlTJUvq4NzJk+G773xH41UwCF9/DStt3Be89JIu+QwYAOXL+44m6nbuhI8/1pJD62obv84/H446ykoPjSlMuSVfX/LH/q4yQGfgHWAjMKzoQzNxKy1NN5fXqHHo0Ndfw6xZ0Lt30m17MMngjjugTBno3993JF5lLHaPHu03Du/WrIHHHoN27f50ESpZfPyxNgG1/V7xrWRJ3SpgyZcxhSfnj8HONUUHkD0BLOWPROwooMmh80TeQeSyIo3SxI8VK2D+/D+VHKamQtmyh81aNiZxVKoEt9yiXQ/X5zSGJPHVqQPnnWddD7n3Xi07HDgwaZd9QiE4+mjtgmniWyAA33wD27f7jsSYxJD7GoRzK3DuCXSadBN0rtcmDm/CcQ3ahMOYP0oOr7zy0KHffoN33oEbbtC2tcYkpHvugf37YfBg35F4FQzCl1/q4k9SGj9e3wf/8Q+oW9d3NF6kp8PYsXDZZVCihO9ozJEKBLRL8axZviMxJjFEXgDm3Fc4dxfaZ/8K4D1gD4e3njfJLi1NL33XqXPo0GuvaflJ794e4zKmqJ18stZYDR4Mu3b5jsabjEXvMWP8xuHFrl3aUei00+Cvf/UdjTezZ8Ovv1rJYaJo0kS3C1jpoTGFI/+7b5w7gHMf4VxXoCraH39aIcdl4tGaNfDVV4eVHKan62fRiy6yjlcmCdx/vy71vvmm70i8OfVUnTSRlF0P+/XTbiODB+tmmSQVCkHx4tC2re9ITGEoXx7OPdeSL2MKy5G1PnBuO869hnMtCykeE88ydtlnSr4mTICffrL28iZJNG+u7cH699c6nSQVDOoHtY0bfUcSRT/+CM88A9dfr8O3k1gopHu9jjnGdySmsAQCem11717fkRgT/6zvnCk8aWl6yfvUUw8dGjRImx527JjL44xJFCI6UHfxYr3ykKSCQc09P/jAdyRR4hz06qVdhZ57znc0Xi1bpmMereQwsQQCun1g3jzfkRgT/7wkXyLSS0RWisgeEZknIoE8zi8pIk+GH7NXRH4Wkbsz3X+ziLhsvo46ktc1+bBhg17qzrTqtWQJTJqkXbht07VJGl266GDd55/3HYk3Z52lW+CSpuvh22/D1Knw739DlSq+o/FqbLj9VocOfuMwhat5c7210kNjjlzUky8RuQYYAPQDzgVmAhNEpFYuD/s/oC066PlU4CpgQZZzdgHVMn855/Yc4euaSH3wgV79zZR8DR6sSdftt3uMy5hoK1FCOx9Onar9mZOQiL4VTJ0Kv//uO5oitnmz7vW78ELo0cN3NN6FQrq/N0kbPSas44/XohZLvow5cj5WvvoCI5xzrzjnFjntoPgL0DO7k0WkNdASaOecm+Kc+8k595VzblqWU51zbn3mryN5XZNPaWlw0kl6yRvYsQNGjICrroKqVf2GZkzUde8O5col9dDlYFBHXYVCviMpYo88Aps2wdChST9B/vff9cO5lRwmpkAAZsxI6u2sxhSKqP6mEJGSQENgcpa7JgNNc3hYJ2AO0FdE1ojIUhF5SUTKZTmvtIisCp/zkYiceySvKyI9RGSuiMw9cOBAZN9gsvr9d73E3aXLoYGib78NW7daow2TpCpWhNtug3ffhbVrfUfjRcOGcOKJCd71cPZsTbruukvbwSW5CRO0w60lX4kpEIAtW+D7731HYkx8i/ZluspAMWBDluMb0Lb12akLNAcaAEGgD1qCOCLTOYuBW4GOwLXo/LEZInJyQV/XOfeyc+5859z5xYsXz/MbS2qhkF7iDpccOqeNNs49Fxo39hybMb7cc49eIh40yHckXojorPXJk2HbNt/RFIEDB+DOO6FaNXjySd/RxIRQSCsdLrjAdySmKATCu+St9NCYIxMPNRIpgAO6hcsNJ6EJWFBEqgA452Y55153zs13zn0BXAMsB+7yFnUyGTVKL3E3bAjA55/rlbE+fQ4thBmTfOrU0exj6FCtw01CwSDs2wfjxvmOpAgMHqx7+vr3hwoVfEfj3b59uvLVoUPSV18mrNq1tXuxJV/GHJlov0VuAtKBrO2gqgBZ92hl+AVY65zbmunYovBtts0ynHPpwFwgY+WrIK9rIrFtG0yZoh8yw5lWaipUqgTXXus5NmN869tX63Ref913JF40aaILQwnX9XDdOnj0UWjdWje2Gj77DLZvt5LDRCaiq19ffKEVLsaYgolq8uWc2wfMA1pluasV2n0wOzOA6ln2eJ0Svl2V3QNERICz0cStoK9rIvHRR3rJM1xyuHatzlq+7TYoXdpzbMb41qSJ1t6++KJuhkkyKSl6XWbCBNi503c0hahvX33fS0215f2wUEjf81u29B2JKUqBgF57WLnSdyTGxC8fxQEvADeLSHcROV1EBgDVgaEAIvKGiLyR6fx3gN+A4SJSX0SaoS3jRznnNoYf85iItBGRuiJyDvAqmnwNjfR1TQGlpeml7SZNABg2TLe59LQeksaovn118mzGAKQkEwzC7t0wcaLvSArJ5MkwciQ8/LB2eDU4p8lX69Z20S3R2b4vY45c1JMv59xI4F7gUWA+2kyjnXMuYxWrFpnKCZ1zO4BLgaPRrofvAZ+hDTYyVAReRssRJwM1gBbOudn5eF2TXzt36iXtzp0hJYW9ezX5uvxy3e5ijEF/PmrXhhde8B2JF4EAVK6cIF0P9+yB3r11gvSDD/qOJmYsWAA//2wlh8mgfn045hhLvow5El7a+DnnBgODc7jv4myOLQZa5/J89wH3HcnrmgKYOFEvaYdLDtPSYONGay9vzGGKF9fOh/fdB3PmJF0ruOLFoVMnXSzauxdKlfId0RH4z390FXPKlDj/RgpXKKTVl5df7jsSU9RSUqBZM0u+jDkS1pPIFFxaGhx7LLRoAej2h5NPhlZZd9YZk+xuvVU74iXp0OVgUJsxTJniO5IjsHQp/Pvf0LUrXHqp72hiSiikWxurZG1pZRJSIABLlsCGrMN7jDERseTLFMzevdpso1MnKF6cr7+GmTO1IsfaDBuTRYUKcPvt8N57Wp+VZP7yF507HbddD53TN7ejjkra8tGcrF0Lc+dayWEyydj3NX263ziMiVf2MdkUzJQpeik7XHKYmgplysBNN3mOy5hYdffdejtwoN84PChZUj+ch0Kwf7/vaApg5Eh9z3v6aW0wZA756CO9teQreTRsqI1VrPTQmIKx5MsUTFoaHH00tGzJb7/BO+/ADTfo1W1jTDZq1dKZUC+/rBcukkwwCJs3w9SpviPJp61bdb9ew4bWxjUboRDUqwenn+47EhMtJUtCo0aWfBlTUJZ8mfzbvx8+/BA6dICSJRk+/I8mYMaYXNx3nw4mf+0135FEXevWUK5cHHY9/Mc/dHPL0KFQrJjvaGLKjh3wySe66mXjzpJLIADz5+vbmTEmfyz5Mvk3bZpewu7ShfR0GDwYLroIzjrLd2DGxLgLL4TmzXXo8oEDvqOJqqOO0m54H3wQR/Om583TmupeveD8831HE3OmTNHtv1ZymHwCAZ3pOWuW70iMiT+WfJn8GzUKypaF1q2ZMEEn3duqlzERuv9++OknzUKSTDCo4yjiYqN+ejrceSccdxw89ZTvaGJSKKQzn5o18x2JibYmTXQh2EoPjck/S75M/qSn64fGyy+H0qUZNAiqV9emh8aYCHTooJtkkrBr3mWX6Ub9uOh6OGyYtvF74QXbzJqN9HRtttGuHZQo4TsaE23lysG551ryZUxBWPJl8mf6dL10HQyydClMmqQXh+2XrzERKlYM7r1X63WSrGanXDlo2xZGj9aSpZi1fj08/DC0bAnXXus7mpg0axZs2mQlh8ksEICvvtLSU2NM5Cz5MvmTlqabN9q1Y/BgTbpuv913UMbEmVtu0XqtJFz9CgZh3Tr90Baz/vpX2L1b93tZJ4lshUL6/t+mje9IjC+BgCZec+f6jsSY+GLJl4ncwYN6ybpNG3ZQjuHDoUsXqFrVd2DGxJmyZeGOO/TnaeVK39FEVfv2+qE9ZrsefvIJvP02PPggnHqq72hiVigEF1+sE0dMcmreXG+t9NCY/LHky0Ru9mxYuxaCQd5+W8ff9OnjOyhj4lSfPpCSAi+95DuSqDr6aGjVSpMv53xHk8XevdrZsG5deOgh39HErMWL9ctKDpPbccfBaadZ8mVMflnyZSKXlgYlSuDadyA1VTfbNmniOyhj4lSNGtC1K/zvf9rEZs8e3xFFTTCoDR+/+cZ3JFk8+ywsWaLlhqVL+44mZo0dq7cdOviNw/gXCMCMGXE0PsKYGGDJl4mMc5p8tWzJF99V5Lvv9MK9bYcw5gg8/LCWIHbuDMcfDzfcoJ9sE3wHe8eO2nckproerlgBTz+ttdRt2/qOJqaFQtCgAZx4ou9IjG+BgFbBfP+970iMiR+WfJnIzJ+ve1OCQQYN0l4BXbv6DsqYOHf66bB6tbYNveoqGDdOa7mqVNGmHBMmwP79vqMsdMceC5dcEkOlh87psMLixXUAtsnRpk260mElhwY0+QIrPTQmPyz5MpFJS4OUFNZe2JnRo+G226BMGd9BGZMASpSA1q3h1Ve1xfm4cTo4b8wYHaJUtSp07w5TpsCBA76jLTTBoFb4/fCD70jQ97eJE+Ff/9JyUJOj8eO195IlXwZ09bNmTUu+jMkPcTFx2TG2lS1b1u3cudN3GH6dfjpUq8ZjgU/5179g2TLdk26MKSJ798LkyTByJHz4IezYAZUra9Zy9dVw0UVauxen1q/XAe2PPaZf3mzfru9vxx0Hc+bo6pfJUZcuOuNr9WrtF2NMt24wbZr247KtCCYSIrLLOVfWdxy+2FunydvChfDjj+zreBXDhsHll1viZUyRK1VKOxq89ZYONh89Gi69VP/csqWu0PTuDZ9/Hpe73atW1VbV3lvOP/aYDh4bMsQSrzzs2aMLhB06WOJl/hAIwC+/6LZJY0ze7O3T5G3UKBAhrURXNmzQz3vGmCgqXVqbcrz7riZi77+vn3iGD9cVsBNOgHvu0c04Bw/6jjZiwSB8952WH3oxf762+u/RAxo39hRE/Jg2DXbutJJDczjb92VM/ljZYQSSvuywQQMoX55mbjobN+p8F7vqaUwM2LEDPvoI3ntPN+Ps3asbMK66Cq65Bi68MKbrgFavhlq1oF8/D2O1Dh6EZs1g+XJ9UzvmmCgHEH969YLXX4fffoOjjvIdjYkVBw9qRXTnzrp11Zi8WNmhMblZtgwWLOCbRncyc6auelniZUyMKFdO246OHq0rYm+9pQP4Bg3SlZw6deCBB2Du3BhpK3i4E06ARo08lR7+73/w5Zfw3HOWeEXAOW0x36aNJV7mcCkpWkJsK1/GRMY+RpvchT8Vpa7tSJkycPPNfsMxxuSgQgW47jr9hLxxI4wYAfXrQ//+cMEFcPLJOlds/vyYSsSCQZg3T4cuR83GjfD3v2vJ5g03RPGF49c332hDBSs5NNkJBGDpUm2kY4zJnSVfJndpafx+zl94+8PyXH89VKzoOyBjTJ4qVoSbbtK29Rs26CpPvXrwzDO6MnbaafCPf+hkVM+JWDCot6NHR/FFH3hASzaHDInpssxYEgrpX9Xll/uOxMSijH1f06f7jcOYeGDJl8nZzz/DnDm8Vu0R9uyxRhvGxKVKlXQw36RJ2pJs2DDdF9avH5x1lq6OPfEELFrkJby6deGcc6JYevjZZ7px6a9/1RbzJiKhEDRtqh35jcnqvPO0L5CVHhqTN0u+TM5GjyadFIZ835wWLeDss30HZIw5Iscdp539PvlE26unpsLxx2vydcYZ+kP+1FNaPxRFwSDMnKllbUVq3z7o2RNq14ZHHy3iF0scq1dr2aGVHJqclCyp20wt+TImb5Z8mZylpTHxxDtZsbokffr4DsYYU6iqVNH2ddOmwZo12nK9QgUtRzzlFC1P/M9/ojK8p0sXvR0zpohf6IUXdIVv4EAoU6aIXyxxjB2rt5Z8mdwEAvDtt7Btm+9IjIlt1mo+AknZan79eqhencvqLWbBrpP56ScoUcJ3UMaYIrdmjc4Re+897QYIcP75cPXV+nXiiUXysvXr6yLc1KlF8vTa0eOMM7RdX5FneYmlbVvNwRcvti1yJmcffwytWsGECfpvxpicWKt5Y7IzZgxLXT0mLjuZO+6wxMuYpFGzJtx3H8yapQnLs8/q8Qce0HK9xo21g+Lq1YX6ssEgfP45/PproT6tcg7uukt7Yg8YUAQvkLi2bYNPP9VVL0u8TG4aN4Zixaz00Ji8WPJlspeWxuCKj1CihKNHD9/BGGO8OPFEbUwxZ44OI/73v3XfVN++Oh25eXMtV1y37ohfKhjUYa0ffFAIcWf14Yc6jPrxxzVuE7HJk2H/fis5NHkrV04bb1jyZUzurOwwAklXdrhpEzur1KVGiQ20u7I077zjOyBjTExZskRLE0eOhO++0yWRQACuuUazqCpV8v2UzukospNOgokTCzHWHTu03PDoo+Hrr20ZP59uvPGPiQXFi/uOxsS6++/XPj5bt0KpUr6jMbHKyg6NyerDD3n7YFe27i1tjTaMMX92yinwyCOwYAEsXAiPPab1gr17Q/Xq0LKltrTftCnipxTRvO2TT2Dz5kKM9ckntURy6FBLvPLpwAFNvC6/3BIvE5lAAPbu1cVyY0z2LPkyf+JGpTGoRF/OOcfRpInvaIwxMe300zX5+uEHXQV75BFt2nHnnVC1qja4ePVV+P33PJ8qGNQP/KFQIcX23Xe6P+2226BZs0J60uQxc6b+b7OSQxOp5s311koPjcmZJV/mcFu28MWUPXy3/zT69BHbYG2MiYwInHmmrjT9+CPMn69NOpYtg+7dtRSxXTsdcLxlS7ZPccEFcMIJhTRw+eBBnel19NHw3/8WwhMmn1BI5ze1aeM7EhMvKlfW6zGWfBmTM0u+zOE++ojU9Ds4pvwBrr3WdzDGmLgkAg0aQL9+mnzNnasdFBcuhJtv1kTsiivgrbcOGwqUUXo4eTJs336EMYwYATNmwDPPwLHHHuGTJR/ntE/JJZdA+fK+ozHxJBDQH730dN+RGBObLPkyh1n71lRGcyW39ShmM0iNMUdOBBo21CRo5UqdHdanD3zzDdxwgw736twZ/u//YMcOgkHdMzJu3BG85m+/6apbs2aa7Jl8W7xY82YrOTT5FQjoNZXvvvMdiTGxyZIv84cdO3j547qkU4yevaze0BhTyESgUSN4/nlYtUovj99xB3z1FVx7LRx/PE1fvJqqFXeT9t6Bgr/Ogw9qu7UhQ3S2l8m3jH13lnyZ/AoE9NZKD43Jnv1WMofsGzuRYem30a7xZurW9R2NMSahpaRA06Y69HjNGvjsM7j1VlKmf07nLcMZP2Yvu7rcCGPGwO7dkT/vjBna4OO+++Css4ou/gQXCunMppo1fUdi4s2JJ+reTUu+jMmeJV/mkNED17KBqvR5tKLvUIwxySQlBVq0gEGDYO1ags81ZRdlmTg5Ba68UksTr79eM4K9e3N+nv37tcviCSfAP/8ZvfgTzK+/aqdDW/UyBRUIaPJlo2SN+TNLvozas4dBX13ISRU20PqyYr6jMcYkq2LFuOieczj2WEi7/DXtvtG1K0yYAB07arOOm2+G8eNh377DHztgAHz/Pbz0EpQr5yX8RDBunH5otuTLFFQgAOvXw/LlviMxJvZY8mUA+Gbol8w42IReXTfbFgljjFfFi0OnTvDR+BT2tmgFr7yin+QmTNDmHB98oJN/q1bVGV6TJ2szj8cfh/btNUkzBRYKabnhOef4jsTEK9v3ZUzOvHzMFpFeIrJSRPaIyDwRCeRxfkkReTL8mL0i8rOI3J3p/ttF5AsR2SwiW0Rkqog0z/Icj4uIy/K1vqi+x3iTmiqUYSc3P2mbvYwx/gWD2jHt44/DB0qUgLZtYfhw2LABxo7VBOz993UQ1Ukn6WyvgQOxAYUFt2cPTJqkq17212gK6vTToVIlS76MyU7Uky8RuQYYAPQDzgVmAhNEpFYuD/s/oC3QAzgVuApYkOn+i4GRwF+ARsBiYJKInJzleRYD1TJ92W5s4Pf1+3hn2QVcf/JsjqlS0nc4xhhDy5Y6HznbgculSukK15tvwsaNuhJ2/fUwbBjUrh3tUBPG77/Dv/4Fu3ZZyaE5Mikp0Ly5JV/GZKe4h9fsC4xwzr0S/vNdItIW6Ak8lPVkEWkNtATqOec2hQ//lPkc59x1WR7TE+iEJmxLM911wDlnq11ZDP/HCnZzGr372GVOY0xsKFkSOnTQQb/79+vCV7aOOkrLDK3UsECc007/Q4fCyJG68tWqFVx8se/ITLwLBLSEdf16rRA2xqiornyJSEmgITA5y12TgaY5PKwTMAfoKyJrRGSpiLwkIrntpi4JHAVsznK8roisC5cv/p+IJH2NXXo6DB5ZiUDKDM7u0dh3OMYYc0gwqKsx06b5jiTxbN+uC4XnnQdNmugK4803w/z5uoWuVCnfEZp4Z/u+zJEowBalbiIyX0R2ich6EXlLRKpmOadCOIdYF97GtExEri7a7+TPol12WBkoBmzIcnwDkNN1kbpAc6ABEAT6oCtaI3J5naeAHUAo07GvgJvDj709/HozReTY7J5ARHqIyFwRmXvgwBEM+4xxE8els2L78fRpPFevIBtjTIxo0wbKls2h9NAUyLffQs+eUL26duV3Tle91q3TmdQNGviO0CSK886DMmUs+TL5l98tSiLSDHgTeB2ojy7cnAG8nemcEsAU4GTganQb083AyqL6PnLio+wwv1IAB3Rzzm0FEJE+6J6uKs65wxI5EbkHuAO41Dm3LeO4c25ClvO+BFYANwEvZH1R59zLwMsAZcuWTdhJFalPb6Eae+l8l03SNMbEltKltafGmDGQmgrFbApGgezeDe+9p0nWl1/qdbauXTX5uvBCa6xhikaJEtC4sSVfpkDytUUJaAKscc71D/95pYgMBAZmOucW4Dgg4JzLmFPyU6FHHoFor3xtAtKBKlmOVwFy2ov1C7A2I/EKWxS+PSwDFpF70VWvds652bkF4pzbAfyAZsBJadkymDD7WO4s/iolOrT1HY4xxvxJMKg9NWbM8B1J/Fm8GPr2hRo1tKRw82bo319XuYYPh0aNLPEyRSsQ0NXWrVvzPtcYKPAWpRlANRHpIKoy0BUYn+mcTuHzBobLEheGO6HntKO4yER15cs5t09E5gGtgPcz3dUKyKmwZAZwlYiUCydMAKeEb1dlnCQifYEngMudc9PzikVEjgJOA6bmdW6lSpWYloCbDlJT61EspTr1/1OPaXPm+A7HGGP+pHz5YpQs2ZQBA37h4MFlvsOJefv3C9OnV2bs2Op8880xFC9+kEBgE1dcsY4GDbYgoh+GjYmG8uUr4tw5DB26gEaNfvcdjokdxUVkbqY/vxyuOIPctyhdmt2TOedmiUhXtMywNJrfTEGr2zLURbuivwNcDtQGUoFywF+P5JvJL3EuuhV14TrON4FeaGJ1J3AbUN85t0pE3gBwzt0YPr8cutL1JfA4UBEYBixyzl0VPudvwNPA9cDnmV5ud6ZSxeeAscDPwPHAP4AWwFnOuVXkomzZsm7nzp1H/L3Hkp07oUbVA1y2433efesgXHdd3g8yxhgPOnWCefNg1SpsCHwOfvpJZ1G/+qqOQatdG+64A265BapkrTUxJkp27oSKFeFvf4N+/XxHY2KFiOxyzpXN4b7qwFrgIufc55mO/xO4zjl3ajaPOQNNtl4EJqHjpJ4F5mfKJ5agzfjqOOfSw8d6AP2Bci6KCVHU93w550aGm1w8iv7lfI+WCWaV7uVcAAAgAElEQVQkQLWynL9DRC5F6zbnoB0MPwD+num03kAJdNZXZq+jm+kAagLvohn1r2gy1zivxCtRvfMObN1RnD7FhkL7UN4PMMYYT4JBbTk/e7buITEqPR3Gj9e9XBMmaAlh+/baUKN1a0tUjX9ly2rjDdv3ZfKhIFuUHgJmO+eeDf95gYjsBL4QkYedc2vQbUz7MxKvsEVAGf7IDaLCS8MN59xgYHAO912czbHFQOtcnq92BK/ZNfIIE5tzMGiQ45wSC2l6aTmdZGqMMTGqQwfdvJ+WZskX6J6tV1/Vla7Vq6FaNfjHP6B7dzjhBN/RGXO4QAAGDtQZctZU2eSlgFuUyqAJW2YZf864DDUD6CYiKc65g+FjpwC70IQvauy6WBKaPh0WLBB67++PdAn6DscYY3JVsSJceqkmX1GulI8ZBw/Cxx9Dly5Qqxb8859w2mkwerSWYz7xhCVeJjYFArBvH9jWcpMPLwA3i0h3ETldRAYA1YGhACLyRsY2pbCxQEcR6SkidcOt518CvnbO/Rw+ZwhQCRggIqeKSBu0V8TgaJYcgiVfSWnQIKh41G66pYyEjh19h2OMMXkKBmHlSh0CnEw2bYLnnoNTT4VWrXTgdN++sHSpDkPu3FlXBY2JVc2b662VHppIOedGAveiW5Tmo/N+s25RqpXp/BFoe/o+6HamUcASoGOmc1ajVXQNw885FHgNeKRov5s/i3rDjXiUSA031q2DE0903FPuNZ5r+K5eSjXGmBi3aRNUrQp//zs89ZTvaIqWc9paf+hQeP99XTUIBHQuVzAIpUr5jtCY/KlfX1dsJ0zI+1yT+HJruJEMbOUrybz8sm7S7rmln/4WN8aYOFC5Mlx0EYwalbilh1u36jDps8/WZGvsWOjRA77/Hj7/HLp1s8TLxKdAAGbO1M8fxiQ7S76SyL59MGwYXHbSUurJSq1XMcaYOBEM6uDghQt9R1K45s2D22+H6tWhTx9tSvC//2mlwsCBumpgTDwLBGDbNliwwHckxvhnyVcSGT0a1q+HPvv6Q7NmWsNjjDFxonNnbaeellO/qziyc6d2LLzgAjj/fB3/0a2bNiWYMwduu03bdBuTCAIBvbV9X8ZY8pVUUlOhXq19tFk1TFtmGWNMHKlWTa8bxXPy9cMPcPfdUKOGtobfvVubIK1bp63jzz/fd4TGFL5atfTLki9jLPlKGvPna4v53md+TgoOrrzSd0jGGJNvwaCWLi1b5juSyO3dqytbLVrAmWdq+Xf79vpB9LvvoHdvG7doEl8goP/mE3XPpjGRsuQrSaSmQunScPPap+HCC20gjDEmLmVcN4qH1a/ly+HBB6FmTbjuOl3devZZWLsW3npLW3CL+I7SmOgIBGDDhvi6cGJMUbDkKwn8/ju8/TZc33E7x3w7zbocGmPiVq1auk8qVpOvAwdgzBho0wZOOgmef15XvCZPhiVL4K9/1c6NxiQb2/dljLLkKwkMH677CnrXGKMHLPkyxsSxYFCbUqxalfe50bJ6NTz2GJx4oq7OLVwITz4JP/+siWKrVpBiv3FNEjv9dDj2WEu+jLEhyxGI5yHLBw/CySfr5u7P05tpi635832HZYwxBbZsmb6vvfAC3HefvzgOHtQVraFDdSaXc9C2LfTsCZddBsWL+4vNmFjUqZPOrbPSw+RmQ5ZNQps4EVasgD7dftcJh7bqZYyJcyedBA0a+Cs93LAB/vMfjeOyy2DWLN3btXw5jB8PHTpY4mVMdgIB/Tn55RffkRjjjyVfCW7QIG3P3HnfSD1gyZcxJgEEg3o9KVof4pyDadOga1ftV/TQQ1C7NowcqSWH/fpBnTrRicWYeGX7voyx5CuhLVsGEybAHXdAiQ/eh9NOgzPO8B2WMcYcsWBQE6IxY4r2dTZvhgED9K3zkku0zLBPH1i0CD79FK6+GkqWLNoYjEkU554LZcpY8mWSmyVfCWzIEC196RH8DT77zFa9jDEJ44wz9HpSUZQeOgdffQW33ALVq8O990LFijBihLaJf+EFfW1jTP6UKAFNmljyZZKbJV8JaudOeO016NIFqs0arTvDLfkyxiSQYFBLAX/9tXCeb/t2HYB83nnQuDGMGgU33wzffKP7um66SeclGmMKLhDQQelbtviOxBg/LPlKUO+8o29svXujl4br1IFzzvEdljHGFJouXfS60ocfHtnzLFgAvXppV9g779SVryFDdCjykCH21mlMYQoE9Gds5kzfkRjjhyVfCcg5bbTRoAE0O2MzfPKJXiIW8R2aMcYUmgYNoG7dgpUe7t4Nb7wBTZvq8wwfrvO5Zs3Sla4774Ty5Qs/ZmOSXePGuiXCSg9NsrJmuAloxgy9kvvKKyAfjYUDB/QSsTHGJBARva704ou60l+xYt6PWbJESwtHjIDff4dTT4X+/eHGG6FSpSIP2ZikV6YMNGxoyZdJXrbylYAGDdIPId26oZeEa9aECy7wHZYxxhS6YBD279chxznZtw/efx9attRk66WX4NJLtVvhokXaUMMSL2OiJxCAOXNgzx7fkRgTfZZ8JZh16zTfuvVWKJO+HSZN0lqaFPtfbYxJPBdcoNeXsis9/OkneOQRqFVLW8IvX67zuFav1vlcl1xi1djG+BAI6EWR2bN9R2JM9FnZYYJ5+WVIT4eePYHx42HvXutyaIxJWCkpen1p2DDtVlimjM43HDpU3wJFoH173cPVujUUK+Y7YmNMs2Z6+8UX0KKF31iMiTZxzvmOIeaVLVvW7dy503cYedq3D048UdskjxuHXur97DNdDrNPHMaYBJXxAe6qq+DLL3Vlq1o16N5dv2rV8h2hMSarM8/UVeuJE31HYqJNRHY558r6jsMXq0VLIGPGwPr10KcP2spr/Hjo3NkSL2NMQmvaVIchv//+H4OXV62CJ5+0xMuYWBUIaLv59HTfkRgTXVZ2mEAGDYJ69aBNGyA0SSctW8mhMSbBFSsGn3+u/12vnt9YjDGRCQS0PPjbb7Vix5hkYStfCeLbb2H6dB0UmpKCXvo95hi4+GLfoRljTJGrV88SL2PiSSCgt9Zy3iQbS74SRGoqlC4Nt9yCNtkIhaBjRyhRwndoxhhjjDGHOeEE3aduyZdJNpZ8JYDNm+Gtt+D663Wxi08+gW3brOTQGGOMMTErENDky3q/mWRiyVcCGD5c+2v07h0+kJYG5ctDq1Ze4zLGGGOMyUkgABs3wtKlviMxJnos+YpzBw/C4MHQvDk0aAAcOAAffqiDbUqV8h2eMcYYY0y2bN+XSUaWfMW5SZNg+fJwe3nQuV6//WYlh8YYY4yJaaedBpUrW/JlkoslX3Fu0CAdJtq5c/hAWhqUKQOXXeY1LmOMMcaY3Iho5Y4lXyaZWPIVx5YtgwkToEcPKFkSrUEcM0YTrzJlfIdnjDHGGJOrQABWrIB163xHYkx0WPIVx4YM0eGiPXqED8ycCevXW8mhMcYYY+KC7fsyycaSrzi1axe89prmWdWrhw+mpekS2OWXe43NGGOMMSYS554LZcta8mWShyVfceqdd2DLlkyNNpyD0aOhdWuoUMFrbMYYY4wxkSheHJo0seTLJA9LvuKQc9po4+yzoVmz8MG5c+Hnn63k0BhjjDFxJRCA777Ti8rGJDpLvuLQjBnw7be66iUSPpiWppePrrjCa2zGGGOMMfkRCOiF5RkzfEdiTNGz5CsODRoEFStCt27hA85p8nXJJVCpktfYjDHGGGPyo1EjKFHCSg9NcrDkK8788ovmWbfeqhtUAViwQPvOW8mhMcYYY+JMmTLQsKElXyY5eEm+RKSXiKwUkT0iMk9EAnmcX1JEngw/Zq+I/Cwid2c5JygiC8P3LxSRzlnuFxF5XETWichuEZkmIvWL4vsrSi+/DAcOQM+emQ6mpWn9YadO3uIyxhhjjCmoQADmzIHdu31HYkzRinryJSLXAAOAfsC5wExggojUyuVh/we0BXoApwJXAQsyPWcTYCTwNnBO+PZ9EWmU6TkeAO4H7gIuADYCU0SkfOF8Z0Vv3z4YOlRnKJ90UqY70tL0XatKFW+xGWOMMcYUVCAA+/fD7Nm+IzGmaPlY+eoLjHDOveKcW+Scuwv4BeiZ3cki0hpoCbRzzk1xzv3knPvKOTct02n3AlOdc0+Hn/NpYFr4OCIi4f/+j3MuzTn3PXATUB7oRpwYM0ZnKB9qLw/w44+wcKGVHBpjjDEmbmV0b7bSQ5Poopp8iUhJoCEwOctdk4GmOTysEzAH6Csia0RkqYi8JCLlMp3TJJvnnJTpOesAVTOf45zbDXyey+vGnNRUqFsX2rbNdDAtTW+vvNJLTMYYY4wxR6pSJTjzTEu+TOKL9spXZaAYsCHL8Q1ocpSdukBzoAEQBPqgJYgjMp1TNY/nrJrpWESvKyI9RGSuiMw9cOBADqFFz7ff6htS796Qkvn/WloaNG4MNWt6i80YY4wx5kgFAjBzpu5tNyZRxUO3wxTAAd3C5YaT0AQsKCJFtsnJOfeyc+5859z5xYsXL6qXiVhqKpQuDbfckungihXwzTdWcmiMMcaYuBcIwI4desHZmEQV7eRrE5AOZE2aqgDrc3jML8Ba59zWTMcWhW8zmnSsz+M512c6FunrxozNm+Gtt+C66+CYYzLdMXq03lryZYwxxpg4Fwj3vrbSQ5PIopp8Oef2AfOAVlnuaoV2PczODKB6lj1ep4RvV4VvZ+XxnCvRJOvQOSJyFBDI5XVjxogR2nq1d+8sd6SlwbnnQp06PsIyxhhjjCk0NWtC7dqWfJnE5qPs8AXgZhHpLiKni8gAoDowFEBE3hCRNzKd/w7wGzBcROqLSDO0Vf0o59zG8DkDgL+IyN9F5DQReQi4hP9v796j5aqrA45/N4RIDA95FQLIu1GCkagoJZAS5aFLpIuFPCJaCAoueVlL8UFLhWJrq1RBXbpUumpEoEVJYQmoYFEgEgmgpZCAIUIAg5AQeYUEEwK7f/zm9k4uN487d+bMzJ3vZ61Zc86Z38zds++Zx57f7/wOXAKQmVlb/nREHB0Rb6IcM/ZC7fE72qabwjHHwKRJdRsXLYI77rDXS5IkjRhTppTiK7PdkUitUXnxlZlXUaZ9Pw+4hzKZxnszs68Xaxf6hxOSmS8AhwJbUmY9/D5wK/DhujazgWnAdMr5v04Ejs/MOXV/+ovAxcDXgbuBccDhmbms6U+yyU47DX7wgwEbr7mmXFt8SZKkEWLKFHjqKXjwwXZHIrVGpD8trNfYsWNz+fLl7Q5jTVOnlnenefPaHYkkSVJT/OY3sPfecOmlcMop7Y6mu73yCjz6KMydC/fdVy5nnAEHHdTeuCJiRWaObW8U7dP+afw0dIsXw223wXnntTsSSZKkpnnDG2C77crQQ4uvDbd0aX+B1VdszZ1bZo/ss+uuDpjqBBZf3ejaa8tgaF9BkiRpBIkoPTNOujG4FSvg/vv7C62+IuvJurm7t94aJk6E6dPLiasnTizXW2zRtrBVx+KrG82cCXvuCW9+c7sjkSRJaqopU8qh7Y8/Djvt1O5o2mP1avjtb9ccMnjfffDQQ/2TkWy6KUyYAO9+dymw+oqsceNKEavOZPHVbZ5+Gn7+czj7bF9ZkiRpxKk/39e0ae2NpdUy4fe/f/WQwfvvh5UrS5uNNoK99oJ99y3nfO0rtPbcEzbeuL3xa+gsvrrND39Yfg5xyKEkSRqBJk2CzTYbecXXc8+9uidr7lx45pn+NuPGlcLqzDP7e7ImTIAxY9oXt5rL4qvbzJwJr389vP3t7Y5EkiSp6UaNggMO6N7jvlauLLM2Diy0fve7/jabb16Kq2OPXXPI4DbbtC9uVcPiq5s8/zzcdBOcfrpDDiVJ0og1ZQqcf37pFdpqq3ZHM7hXXoFHHnn1kMEHHyyDlAA22QTe+MbyfPoKrIkTYZdd/CrXqyy+uskNN8CqVQ45lCRJI9qUKeV4qNtvh/e9r93RwJIlr+7JmjcP6k8Du/vupbg66qj+3qzx40sBJvWx+OomM2fCDjvA5MntjkSSJKll9t+/FC2zZlVbfC1fXoqqgYXWkiX9bbbdthRWH/lIf0/WPvuUoYTS+lh8dYsVK+DHP4aTTirT3kiSJI1QY8bAfvu17riv1athwYJXDxl8+OH+qdzHjClF1RFHrHlc1vbbO2RQjbP46hY/+UkpwBxyKEmSesCUKXDxxfDii43P9pcJixa9uifrgQfKkRxQftMePx7e+lY48cT+Qmv33Z3KXc1n8dUtZs4sU+AcfHC7I5EkSWq5KVPgi1+EOXNg6tT1t3/22TV7sfqWn322v81OO5XC6vDD+3uy9t67nLBYqoLFVzdYuRKuu67MRzrKf5kkSRr5DjywDO+bNWvN4mvlytJzNXDI4KJF/W223LIUV9OmrTlksFNnTlTv8Jt8N/jpT2HZMoccSpKknrHVVqVguuaast5XbC1YAC+/XLaNHl16rqZOXXMq95139rgsdSaLr24wcyZssQUccki7I5EkSarMoYeW477uuQf22KMUV8cc09+btddeTuWu7hLZN6WL1mrs2LG5vP5EDlXrO7nEu97VvhgkSZIqtmIFzJ9fJsQYO7bd0agZImJFZq7zvxkRpwOfBMYB84BPZOZa576MiBOATwHjgeeB/wbOycwnB2n7AeBK4IbMrPwschZfG6DtxZckSZI0Aqyv+IqI44HLgdOBX9SuTwYmZOZjg7Q/ELgNOAe4Ftge+AbwTGYeMqDtHrW2DwPPt6P48oRRkiRJkjrF2cCMzLw0Mx/IzLOAJ4DT1tL+AGBRZl6cmQsz8w7ga8D+9Y0iYhPgP4C/oxRfbeExXxtg66235pZbbml3GJIkSVK3GxURd9etfzszvw0QEaOBtwH/OuA+NwGT1/J4twOfj4gjgeuBbYBpwI8GtPsn4JHM/G5EvHOYz6FhFl8b4Omnn2bqhpxgQpIkSdK6rM7M/dZy27bAxsDiAdsXA4cOdofM/GVETAOuAMZQ6pufAif1tYmIw4HjgEnDC334HHYoSZIkqStFxATKMMPPUXrN3gPsAHyrdvt2wAzgpMx8di0PUxl7viRJkiR1gqXAy5RJM+ptD7xq5sKac4E7M/Oi2vq9EbEcmBURfwvsRZk18eboP/nbRgARsRrYJzPnN+8prJs9X5IkSZLaLjNXAb8CDhtw02HA7LXc7bWUgq1e3/pGwF3ARMqQw77LD4FZteWFww58COz5kiRJktQpvgx8LyLupEym8TFgR+CbABFxGUBmnlhrfx1waUScBtxI6eW6BPh13dT0c+v/QEQ8C4zKzDW2V8HiS5IkSVJHyMyrImIb4DxKITUXeG9mPlprssuA9jMiYnPgTOBLwHPAz4BPVxf1hvMkyxvAkyxLkiRJw7e+kyyPdB7zJUmSJEkVsPiSJEmSpApYfEmSJElSBSy+JEmSJKkCFl+SJEmSVAGLL0mSJEmqgFPNb4CIeAV4sc1hjAJWtzmGkcJcNod5bA7z2DzmsjnMY/OYy+Ywj83TCbkck5k92wFk8dUlIuLuzNyv3XGMBOayOcxjc5jH5jGXzWEem8dcNod5bB5z2X49W3VKkiRJUpUsviRJkiSpAhZf3ePb7Q5gBDGXzWEem8M8No+5bA7z2DzmsjnMY/OYyzbzmC9JkiRJqoA9X5IkSZJUAYsvSZIkSaqAxZckSZIkVcDiq0NExOkRsTAi/hgRv4qIKetoOy4iroyI30TEyxExo8JQO9oQ83h0RNwUEU9FxLKImBMRf1FlvJ1siLk8OCJmR8QfIuLF2r55TpXxdqqh5HHA/Q6KiNURMbfVMXaLIe6TUyMiB7m8scqYO9FQ98mIGB0RF9buszIiHouIj1cVbycb4j45Yy375PIqY+5EDeyTJ0TEPRGxIiKejIjLI2KHquLtVA3k8YyIeKD2uT0/Ik6sKtZeZvHVASLieOArwOeBtwCzgR9HxC5ructrgKXAvwBzKgmyCzSQx4OBnwFH1Nr/CLhmQ78cj2QN5PIF4KvAnwMTgH8E/iEiTq8g3I7VQB777rcVcBlwc8uD7BKN5hLYBxhXd1nQyjg7XYN5/E/gPcBHgTcAxwL3tjjUjtdALv+KNffFccDDwPdbH23nGmoeI+JA4HvAdymv76MonztXVBJwh2ogj6cBXwAupOTxfODrEXFkNRH3Lmc77AARMQe4NzNPrdu2ALg6M89dz32vB5Zm5vTWRtn5hpPHuvZ3ArMy829aFGZXaFIu/wtYmZkfaFGYHa/RPNZy979AAMdk5ptaHmyHG2ouI2Iq8HNgu8xcWlmgHa6BPB4O/ADY0zyuabjvk7Ui4hfAgZk5u3WRdrYG9slzgLMyc9e6bScDX8vMzaqIuRM1kMfZwJzM/Ou6bV8C9s/Mg6qIuVfZ89VmETEaeBtw04CbbgImVx9Rd2piHjcHnmlWXN2oGbmMiLfU2t7a3Oi6R6N5rPUWbk/pPRTD3ifvjognIuLmiHhnSwLsEg3m8SjgLuDsiFgUEQsi4qsR0bNfcqFpnzmnAvN6vPBqJI+3A+Mi4sgotgWmUUav9KQG8/ga4I8Dtr0IvCMiNmluhKpn8dV+2wIbA4sHbF8M9Pz45SEYdh4j4gxgZ8pwhl7WcC5rX85WAncD38jMb7YmxK4w5DxGxETK0I8PZebLrQ2vqzSyTz4BnAa8HzgamA/c3OPDihvJ4x7AQcC+lFyeSRmCOKM1IXaNYX3mRMSWwHHApc0PrasMOY+Z+UtKsXUFsAp4ijJK4KTWhdnxGtkfbwQ+HBFvrxWx+wGnAJvUHk8tMqrdAUidICLeD1wEHJ+Zj7Y7ni42BdgM+DPgCxGxMDN7vZjdIBHxGuAq4JzMXNjueLpdZs6nFFx9fhkRuwGfBGa1I6YutRGQwAmZ+RxARJwJ3BgR22fmwC972jAfouTW98chiogJwNeAz1EKiHGUz+9vAU4YseE+RynMZlOK18WU4+g+BbzSxrhGPHu+2m8p8DJlmFG97YEnqw+nazWcx4g4hvIBeGJmXtea8LpKw7nMzIWZeV9mXgp8GbigJRF2h6HmcRywN/CdKLMcrgY+C+xTWz+8pdF2tma9T84B/rRZQXWhRvL4BPB4X+FV80Dten2TnYxkw90nTwVmZubTzQ6syzSSx3OBOzPzosy8NzNvBE4H/jIidm5dqB1tyHnMzBcz88PAa4HdKK/nR4BllN5EtYjFV5tl5irgV8BhA246jPJrhDZAo3mMiOMohdf0zLy6dRF2jybukxtRxpT3pAby+DgwEZhUd/km8Nvacs++HzRxn5xEKSZ6UoN5vB3YccAxXuNr1z07SmA4+2REvIMyjLPXhxw2msfXUgqNen3rPfm9djj7Y2a+lJmLakPdpwHXZ6Y9Xy3ksMPO8GXge7WZ9m4HPgbsSPniRURcBpCZ/9+dHhGTaotbAK/U1ldl5v1VBt5hhpTHiJhGKbzOAW6rO0fIKn+NHHIuzwIW0j/M688pef1GtWF3nA3OY2a+BKxxTq+IWEKZMdJzfQ19n/wE5VfcecBoyjCvoyjHLfWyoX7eXAn8PaVH9gLgdZTprK/OzCXVht5xhvzZXfNRYEFm3lJdqB1tqHm8Dri0NlV637DDS4BfZ+ZjFcfeSYb6Hjke2B+4A9gKOBt4E7197FwlLL46QGZeFRHbAOdR3kTmAu+tO/ZosKEd/zNg/UjKr5C7tSrOTtdAHj9GeQ1cUrv0uRWY2tpoO1sDudyYcr6Q3YDVwEPAZ6i96feqBl/bGkQDuRxNOQ5kZ8oMXvOAIzKzZ2dEg6HnMTNfiIhDKcfY3EWZDfZayuu7pzXy+o6IzSm9CxdWFmiHa2CfnFHL45nAl4DnKOfs/HR1UXeeBj+3z6acu+8lyqk5JmfmI9VE3Ls8z5ckSZIkVaAnx8ZKkiRJUtUsviRJkiSpAhZfkiRJklQBiy9JkiRJqoDFlyRJkiRVwOJLkiRJkipg8SVJWquIuCAisna5oN3xDKYW4wURMX0D2u5W93zWd5nR+uglSb3EkyxLkrrd+bXrW4EZbYxDkqR1sudLktQzMvORzIy+C/DOuptvrb8tM6e3KUxJ0ghl8SVJGrKImFE3PG9yRFweEc9ExB8iYmZE7FDXtn6o34yIODkiHoiIlRExf+BwwYi4pa/9urZHxPQBbQ6u+zu3NPG5fj4i5kTE4ohYFRHLI+KeiPhURGxS1+49dX//M+vbLknqPQ47lCQN1w3A6+rWjwa2BA4dpO0RwEl16+OB70TERpn5760LcVhOAHatW98E2Ld22R04rR1BSZK6jz1fkqThWgjsSSmkltS2HRIR4wZpuy2l+NoC+GDd9n+u70XaEJk5ozZ0sE/9sMGpQ3ms9TgH2JtSUI6mPM95tdtOiYjNmvi3JEkjmMWXJGm4PpuZD2fmAmBW3fZdB2k7OzMvy8xlmXklMLu2/U+AN7c60AYtB74KPAS8CDwI7FO7bRSl8JQkab0cdihJGq75dcvL65Y3HaTtY4OsT64tb7uev1P5Z1ZEvIsyrDLW0WzMeh7Gz1pJEmDPlyRp+F6qW861tip2Wcf60tr1yr4NEbFp7Toox1dV7Tj6C68Lgc1qQx1/NEjblXXL9YXnHi2KTZLUZSy+JElVmhwRH4yIzSLiBPp7vZYA99aWH61rf2Tt+ixgx7U85h9q17tGxFZNjRZW1y0vA16OiKOAwwZpWx/34RExOiJ2BD7e5JgkSV3K4kuSVKUngMsphcwVddvPzcy+HrT67d+PiGXAVyjHWw3mjtr1bsDTtSndL2hSvNfULV9Ui+Fq4HcDG2bmw3WxHAA8U2s32MQjkqQeZPElSarSTZRZDh8AVgELgJPrp5nPzFuBUygTW6ykTHRxLHDnWh7zLMowwGeaHWxm3gxMr4tlLmUq/bvWcpfjgOuB54AVwL8BpzY7LklSd4rM9Q3PlySpcRGxG2U6eoDvZub0tgUjSVIb2fMlSfa38eoAAABCSURBVJIkSRWw+JIkSZKkCjjsUJIkSZIqYM+XJEmSJFXA4kuSJEmSKmDxJUmSJEkVsPiSJEmSpApYfEmSJElSBf4PuTojAjH4Pt0AAAAASUVORK5CYII=\n",
       "text/plain": [
        "<Figure size 936x504 with 2 Axes>"
       ]

--- a/examples/demo_meta_classifier.ipynb
+++ b/examples/demo_meta_classifier.ipynb
@@ -1,0 +1,516 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.append(\"../\")\n",
+    "from aif360.datasets import BinaryLabelDataset\n",
+    "from aif360.datasets import AdultDataset, GermanDataset, CompasDataset\n",
+    "from aif360.metrics import BinaryLabelDatasetMetric\n",
+    "from aif360.metrics import ClassificationMetric\n",
+    "from aif360.metrics.utils import compute_boolean_conditioning_vector\n",
+    "from sklearn.linear_model import LogisticRegression\n",
+    "from sklearn.preprocessing import StandardScaler, MaxAbsScaler\n",
+    "from sklearn.metrics import accuracy_score\n",
+    "\n",
+    "from aif360.algorithms.preprocessing.optim_preproc_helpers.data_preproc_functions import load_preproc_data_adult, load_preproc_data_compas, load_preproc_data_german\n",
+    "\n",
+    "from aif360.algorithms.inprocessing.meta_fair_classifier import MetaFairClassifer\n",
+    "from IPython.display import Markdown, display\n",
+    "import matplotlib.pyplot as plt\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset_orig = load_preproc_data_adult()\n",
+    "\n",
+    "privileged_groups = [{'sex': 1}]\n",
+    "unprivileged_groups = [{'sex': 0}]\n",
+    "\n",
+    "dataset_orig_train, dataset_orig_test = dataset_orig.split([0.7], shuffle=True)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "#### Training Dataset shape"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(34189, 18)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "#### Favorable and unfavorable labels"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(1.0, 0.0)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "#### Protected attribute names"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['sex', 'race']\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "#### Privileged and unprivileged protected attribute values"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "([array([1.]), array([1.])], [array([0.]), array([0.])])\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "#### Dataset feature names"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['race', 'sex', 'Age (decade)=10', 'Age (decade)=20', 'Age (decade)=30', 'Age (decade)=40', 'Age (decade)=50', 'Age (decade)=60', 'Age (decade)=>=70', 'Education Years=6', 'Education Years=7', 'Education Years=8', 'Education Years=9', 'Education Years=10', 'Education Years=11', 'Education Years=12', 'Education Years=<6', 'Education Years=>12']\n"
+     ]
+    }
+   ],
+   "source": [
+    "display(Markdown(\"#### Training Dataset shape\"))\n",
+    "print(dataset_orig_train.features.shape)\n",
+    "display(Markdown(\"#### Favorable and unfavorable labels\"))\n",
+    "print(dataset_orig_train.favorable_label, dataset_orig_train.unfavorable_label)\n",
+    "display(Markdown(\"#### Protected attribute names\"))\n",
+    "print(dataset_orig_train.protected_attribute_names)\n",
+    "display(Markdown(\"#### Privileged and unprivileged protected attribute values\"))\n",
+    "print(dataset_orig_train.privileged_protected_attributes, \n",
+    "      dataset_orig_train.unprivileged_protected_attributes)\n",
+    "display(Markdown(\"#### Dataset feature names\"))\n",
+    "print(dataset_orig_train.feature_names)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import Markdown, display\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "#### Training Dataset shape"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(34189, 18)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "#### Favorable and unfavorable labels"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(1.0, 0.0)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "#### Protected attribute names"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['sex', 'race']\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "#### Privileged and unprivileged protected attribute values"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "([array([1.]), array([1.])], [array([0.]), array([0.])])\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "#### Dataset feature names"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['race', 'sex', 'Age (decade)=10', 'Age (decade)=20', 'Age (decade)=30', 'Age (decade)=40', 'Age (decade)=50', 'Age (decade)=60', 'Age (decade)=>=70', 'Education Years=6', 'Education Years=7', 'Education Years=8', 'Education Years=9', 'Education Years=10', 'Education Years=11', 'Education Years=12', 'Education Years=<6', 'Education Years=>12']\n"
+     ]
+    }
+   ],
+   "source": [
+    "display(Markdown(\"#### Training Dataset shape\"))\n",
+    "print(dataset_orig_train.features.shape)\n",
+    "display(Markdown(\"#### Favorable and unfavorable labels\"))\n",
+    "print(dataset_orig_train.favorable_label, dataset_orig_train.unfavorable_label)\n",
+    "display(Markdown(\"#### Protected attribute names\"))\n",
+    "print(dataset_orig_train.protected_attribute_names)\n",
+    "display(Markdown(\"#### Privileged and unprivileged protected attribute values\"))\n",
+    "print(dataset_orig_train.privileged_protected_attributes, \n",
+    "      dataset_orig_train.unprivileged_protected_attributes)\n",
+    "display(Markdown(\"#### Dataset feature names\"))\n",
+    "print(dataset_orig_train.feature_names)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Train set: Difference in mean outcomes between unprivileged and privileged groups = -0.197918\n",
+      "Test set: Difference in mean outcomes between unprivileged and privileged groups = -0.186511\n",
+      "Train set: Difference in mean outcomes between unprivileged and privileged groups = -0.197918\n",
+      "Test set: Difference in mean outcomes between unprivileged and privileged groups = -0.186511\n"
+     ]
+    }
+   ],
+   "source": [
+    "metric_orig_train = BinaryLabelDatasetMetric(dataset_orig_train, \n",
+    "                                             unprivileged_groups=unprivileged_groups,\n",
+    "                                             privileged_groups=privileged_groups)\n",
+    "#display(Markdown(\"#### Original training dataset\"))\n",
+    "print(\"Train set: Difference in mean outcomes between unprivileged and privileged groups = %f\" % metric_orig_train.mean_difference())\n",
+    "metric_orig_test = BinaryLabelDatasetMetric(dataset_orig_test, \n",
+    "                                             unprivileged_groups=unprivileged_groups,\n",
+    "                                             privileged_groups=privileged_groups)\n",
+    "print(\"Test set: Difference in mean outcomes between unprivileged and privileged groups = %f\" % metric_orig_test.mean_difference())\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n",
+    "min_max_scaler = MaxAbsScaler()\n",
+    "dataset_orig_train.features = min_max_scaler.fit_transform(dataset_orig_train.features)\n",
+    "dataset_orig_test.features = min_max_scaler.transform(dataset_orig_test.features)\n",
+    "metric_scaled_train = BinaryLabelDatasetMetric(dataset_orig_train, \n",
+    "                             unprivileged_groups=unprivileged_groups,\n",
+    "                             privileged_groups=privileged_groups)\n",
+    "#display(Markdown(\"#### Scaled dataset - Verify that the scaling does not affect the group label statistics\"))\n",
+    "print(\"Train set: Difference in mean outcomes between unprivileged and privileged groups = %f\" % metric_scaled_train.mean_difference())\n",
+    "metric_scaled_test = BinaryLabelDatasetMetric(dataset_orig_test, \n",
+    "                             unprivileged_groups=unprivileged_groups,\n",
+    "                             privileged_groups=privileged_groups)\n",
+    "print(\"Test set: Difference in mean outcomes between unprivileged and privileged groups = %f\" % metric_scaled_test.mean_difference())\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "('-----', [0.0, -1], [0.01, -1])\n",
+      "(0.792155371610752, 0.7957535203866768)\n",
+      "('-----', [0.1, -1], [0.11, -1])\n",
+      "(0.7922431191318845, 0.798153210372909)\n",
+      "('-----', [0.2, -1], [0.21, -1])\n",
+      "(0.7939980695545351, 0.8009337814115932)\n",
+      "('-----', [0.3, -1], [0.31, -1])\n",
+      "(0.795870016672029, 0.8347649869941323)\n",
+      "('-----', [0.4, -1], [0.41000000000000003, -1])\n",
+      "(0.795870016672029, 0.8347649869941323)\n",
+      "('-----', [0.5, -1], [0.51, -1])\n",
+      "(0.7998479042967036, 0.778176074821347)\n",
+      "('-----', [0.6, -1], [0.61, -1])\n",
+      "(0.7998479042967036, 0.778176074821347)\n",
+      "('-----', [0.7000000000000001, -1], [0.71, -1])\n",
+      "(0.7998479042967036, 0.778176074821347)\n",
+      "('-----', [0.8, -1], [0.81, -1])\n",
+      "(0.7998479042967036, 0.778176074821347)\n",
+      "('-----', [0.9, -1], [0.91, -1])\n",
+      "(0.7998479042967036, 0.778176074821347)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<aif360.algorithms.inprocessing.meta_fair_classifier.MetaFairClassifer at 0x111f03d90>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Learn debiased classifier\n",
+    "debiased_model = MetaFairClassifer(sensitive_attr=\"race\")\n",
+    "debiased_model.fit(dataset_orig_train)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Apply the plain model to test data\n",
+    "dataset_debiasing_train = debiased_model.predict(dataset_orig_train)\n",
+    "dataset_debiasing_test = debiased_model.predict(dataset_orig_test)\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "#### Model - with debiasing - dataset metrics"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Train set: Difference in mean outcomes between unprivileged and privileged groups = -0.199196\n",
+      "Test set: Difference in mean outcomes between unprivileged and privileged groups = -0.198363\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Metrics for the dataset from model with debiasing\n",
+    "display(Markdown(\"#### Model - with debiasing - dataset metrics\"))\n",
+    "metric_dataset_debiasing_train = BinaryLabelDatasetMetric(dataset_debiasing_train, \n",
+    "                                             unprivileged_groups=unprivileged_groups,\n",
+    "                                             privileged_groups=privileged_groups)\n",
+    "\n",
+    "print(\"Train set: Difference in mean outcomes between unprivileged and privileged groups = %f\" % metric_dataset_debiasing_train.mean_difference())\n",
+    "\n",
+    "metric_dataset_debiasing_test = BinaryLabelDatasetMetric(dataset_debiasing_test, \n",
+    "                                             unprivileged_groups=unprivileged_groups,\n",
+    "                                             privileged_groups=privileged_groups)\n",
+    "\n",
+    "print(\"Test set: Difference in mean outcomes between unprivileged and privileged groups = %f\" % metric_dataset_debiasing_test.mean_difference())\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "#### Model - with debiasing - classification metrics"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Test set: Classification accuracy = 0.804545\n",
+      "Test set: Balanced classification accuracy = 0.667498\n",
+      "Test set: Disparate impact = 0.099545\n",
+      "Test set: Equal opportunity difference = -0.390577\n",
+      "Test set: Average odds difference = -0.245169\n",
+      "Test set: Theil_index = 0.170302\n"
+     ]
+    }
+   ],
+   "source": [
+    "display(Markdown(\"#### Model - with debiasing - classification metrics\"))\n",
+    "classified_metric_debiasing_test = ClassificationMetric(dataset_orig_test, \n",
+    "                                                 dataset_debiasing_test,\n",
+    "                                                 unprivileged_groups=unprivileged_groups,\n",
+    "                                                 privileged_groups=privileged_groups)\n",
+    "print(\"Test set: Classification accuracy = %f\" % classified_metric_debiasing_test.accuracy())\n",
+    "TPR = classified_metric_debiasing_test.true_positive_rate()\n",
+    "TNR = classified_metric_debiasing_test.true_negative_rate()\n",
+    "bal_acc_debiasing_test = 0.5*(TPR+TNR)\n",
+    "print(\"Test set: Balanced classification accuracy = %f\" % bal_acc_debiasing_test)\n",
+    "print(\"Test set: Disparate impact = %f\" % classified_metric_debiasing_test.disparate_impact())\n",
+    "print(\"Test set: Equal opportunity difference = %f\" % classified_metric_debiasing_test.equal_opportunity_difference())\n",
+    "print(\"Test set: Average odds difference = %f\" % classified_metric_debiasing_test.average_odds_difference())\n",
+    "print(\"Test set: Theil_index = %f\" % classified_metric_debiasing_test.theil_index())\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# # \n",
+    "#     References:\n",
+    "#         Celis, L. E., Huang, L., Keswani, V., & Vishnoi, N. K. (2018). \n",
+    "#         \"Classification with Fairness Constraints: A Meta-Algorithm with Provable Guarantees.\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/demo_meta_classifier.ipynb
+++ b/examples/demo_meta_classifier.ipynb
@@ -20,6 +20,7 @@
     "from aif360.algorithms.preprocessing.optim_preproc_helpers.data_preproc_functions import load_preproc_data_adult, load_preproc_data_compas, load_preproc_data_german\n",
     "\n",
     "from aif360.algorithms.inprocessing.meta_fair_classifier import MetaFairClassifer\n",
+    "from aif360.algorithms.inprocessing.celisMeta.utils import getStats\n",
     "from IPython.display import Markdown, display\n",
     "import matplotlib.pyplot as plt\n"
    ]
@@ -157,17 +158,6 @@
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {},
-   "outputs": [],
-   "source": [
-    "from IPython.display import Markdown, display\n",
-    "import matplotlib.pyplot as plt\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -281,17 +271,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Train set: Difference in mean outcomes between unprivileged and privileged groups = -0.197918\n",
-      "Test set: Difference in mean outcomes between unprivileged and privileged groups = -0.186511\n",
-      "Train set: Difference in mean outcomes between unprivileged and privileged groups = -0.197918\n",
-      "Test set: Difference in mean outcomes between unprivileged and privileged groups = -0.186511\n"
+      "Train set: Difference in mean outcomes between unprivileged and privileged groups = -0.194402\n",
+      "Test set: Difference in mean outcomes between unprivileged and privileged groups = -0.194759\n",
+      "Train set: Difference in mean outcomes between unprivileged and privileged groups = -0.194402\n",
+      "Test set: Difference in mean outcomes between unprivileged and privileged groups = -0.194759\n"
      ]
     }
    ],
@@ -325,67 +315,48 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "('-----', [0.0, -1], [0.01, -1])\n",
-      "(0.792155371610752, 0.7957535203866768)\n",
-      "('-----', [0.1, -1], [0.11, -1])\n",
-      "(0.7922431191318845, 0.798153210372909)\n",
-      "('-----', [0.2, -1], [0.21, -1])\n",
-      "(0.7939980695545351, 0.8009337814115932)\n",
-      "('-----', [0.3, -1], [0.31, -1])\n",
-      "(0.795870016672029, 0.8347649869941323)\n",
-      "('-----', [0.4, -1], [0.41000000000000003, -1])\n",
-      "(0.795870016672029, 0.8347649869941323)\n",
-      "('-----', [0.5, -1], [0.51, -1])\n",
-      "(0.7998479042967036, 0.778176074821347)\n",
-      "('-----', [0.6, -1], [0.61, -1])\n",
-      "(0.7998479042967036, 0.778176074821347)\n",
-      "('-----', [0.7000000000000001, -1], [0.71, -1])\n",
-      "(0.7998479042967036, 0.778176074821347)\n",
-      "('-----', [0.8, -1], [0.81, -1])\n",
-      "(0.7998479042967036, 0.778176074821347)\n",
-      "('-----', [0.9, -1], [0.91, -1])\n",
-      "(0.7998479042967036, 0.778176074821347)\n"
+      "('Training Accuracy: ', 0.7888209658077159, ', Training gamma: ', 0.8466343589061862)\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<aif360.algorithms.inprocessing.meta_fair_classifier.MetaFairClassifer at 0x111f03d90>"
+       "<aif360.algorithms.inprocessing.meta_fair_classifier.MetaFairClassifer at 0x10cdc9e50>"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# Learn debiased classifier\n",
-    "debiased_model = MetaFairClassifer(sensitive_attr=\"race\")\n",
+    "tau = 0.8\n",
+    "debiased_model = MetaFairClassifer(tau=tau, sensitive_attr=\"race\")\n",
     "debiased_model.fit(dataset_orig_train)\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Apply the plain model to test data\n",
     "dataset_debiasing_train = debiased_model.predict(dataset_orig_train)\n",
-    "dataset_debiasing_test = debiased_model.predict(dataset_orig_test)\n",
-    "\n"
+    "dataset_debiasing_test = debiased_model.predict(dataset_orig_test)\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -404,8 +375,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Train set: Difference in mean outcomes between unprivileged and privileged groups = -0.199196\n",
-      "Test set: Difference in mean outcomes between unprivileged and privileged groups = -0.198363\n"
+      "Train set: Difference in mean outcomes between unprivileged and privileged groups = -0.226253\n",
+      "Test set: Difference in mean outcomes between unprivileged and privileged groups = -0.228184\n"
      ]
     }
    ],
@@ -427,7 +398,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -446,12 +417,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Test set: Classification accuracy = 0.804545\n",
-      "Test set: Balanced classification accuracy = 0.667498\n",
-      "Test set: Disparate impact = 0.099545\n",
-      "Test set: Equal opportunity difference = -0.390577\n",
-      "Test set: Average odds difference = -0.245169\n",
-      "Test set: Theil_index = 0.170302\n"
+      "Test set: Classification accuracy = 0.789463\n",
+      "Test set: Balanced classification accuracy = 0.707496\n",
+      "Test set: Disparate impact = 0.267508\n",
+      "Test set: Equal opportunity difference = -0.342941\n",
+      "Test set: Average odds difference = -0.232800\n",
+      "Test set: Theil_index = 0.147200\n"
      ]
     }
    ],
@@ -474,7 +445,280 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "('Accuracy : ', 3085, 14653, 0.7894629086193954)\n",
+      "('SR tau : ', 0.6335828819141526)\n",
+      "('FPR tau : ', 0.6651902296035078)\n",
+      "('FNR tau : ', 0.9344431946006749)\n",
+      "('TPR tau : ', 0.9435242131376297)\n",
+      "('TNR tau : ', 0.9466027927717635)\n",
+      "('AR tau : ', 0.9175061708874659)\n",
+      "('FDR tau : ', 0.830043185477968)\n",
+      "('FOR tau : ', 0.5406237682301932)\n",
+      "('PPR tau : ', 0.8433187186542124)\n",
+      "('NPR tau : ', 0.924708780005249)\n"
+     ]
+    }
+   ],
+   "source": [
+    "### Testing \n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "predictions = list(dataset_debiasing_test.labels)\n",
+    "predictions = [1 if y == dataset_orig_train.favorable_label else -1 for y in predictions]\n",
+    "y_test = np.array([1 if y == [dataset_orig_train.favorable_label] else -1 for y in dataset_orig_test.labels])\n",
+    "x_control_test = pd.DataFrame(data=dataset_orig_test.features, columns=dataset_orig_test.feature_names)[\"race\"]\n",
+    "\n",
+    "acc, sr, fdr = getStats(y_test, predictions, x_control_test)\n",
+    "\n",
+    "# We give a 0.1 buffer since if the constraint might not be exactly satisfied if the \n",
+    "# normal distribution is not a good fit for the training data.\n",
+    "assert fdr >= tau - 0.1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "#### Running the algorithm for different tau values"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tau: 0.10\n",
+      "('Training Accuracy: ', 0.7076837579338384, ', Training gamma: ', 0.8515484318287467)\n",
+      "('Accuracy : ', 4268, 14653, 0.7087285880024569)\n",
+      "('SR tau : ', 0.7542862733882257)\n",
+      "('FPR tau : ', 0.8029785756264359)\n",
+      "('FNR tau : ', 0.907716535433071)\n",
+      "('TPR tau : ', 0.973575036075036)\n",
+      "('TNR tau : ', 0.9123443457370778)\n",
+      "('AR tau : ', 0.9475531524465962)\n",
+      "('FDR tau : ', 0.8186068256194482)\n",
+      "('FOR tau : ', 0.520823267948594)\n",
+      "('PPR tau : ', 0.7309292649098476)\n",
+      "('NPR tau : ', 0.9523649427495581)\n",
+      "Tau: 0.20\n",
+      "('Training Accuracy: ', 0.7143818187136213, ', Training gamma: ', 0.8740107239918714)\n",
+      "('Accuracy : ', 4167, 14653, 0.7156213744625675)\n",
+      "('SR tau : ', 0.6804186910415122)\n",
+      "('FPR tau : ', 0.7090519728192776)\n",
+      "('FNR tau : ', 0.7691338582677166)\n",
+      "('TPR tau : ', 0.9203232001159463)\n",
+      "('TNR tau : ', 0.8789558573886078)\n",
+      "('AR tau : ', 0.9233239855403916)\n",
+      "('FDR tau : ', 0.8362599159812782)\n",
+      "('FOR tau : ', 0.5883645137475918)\n",
+      "('PPR tau : ', 0.7659602999295992)\n",
+      "('NPR tau : ', 0.9585260144445069)\n",
+      "Tau: 0.30\n",
+      "('Training Accuracy: ', 0.7259352423294042, ', Training gamma: ', 0.8537125021298012)\n",
+      "('Accuracy : ', 3988, 14653, 0.7278373029413772)\n",
+      "('SR tau : ', 0.7330044689928891)\n",
+      "('FPR tau : ', 0.7827902432716137)\n",
+      "('FNR tau : ', 0.9027438628994905)\n",
+      "('TPR tau : ', 0.9642543907434846)\n",
+      "('TNR tau : ', 0.9189050747980114)\n",
+      "('AR tau : ', 0.9406544636475846)\n",
+      "('FDR tau : ', 0.816026633595986)\n",
+      "('FOR tau : ', 0.5304400418327446)\n",
+      "('PPR tau : ', 0.7449500063116703)\n",
+      "('NPR tau : ', 0.9470110473041506)\n",
+      "Tau: 0.40\n",
+      "('Training Accuracy: ', 0.7291526514375969, ', Training gamma: ', 0.87324761369921)\n",
+      "('Accuracy : ', 3933, 14653, 0.7315908005186651)\n",
+      "('SR tau : ', 0.6360982831029656)\n",
+      "('FPR tau : ', 0.6557415047511852)\n",
+      "('FNR tau : ', 0.7532376100046317)\n",
+      "('TPR tau : ', 0.8911200004359886)\n",
+      "('TNR tau : ', 0.877572625280048)\n",
+      "('AR tau : ', 0.9127393716667752)\n",
+      "('FDR tau : ', 0.8453463181953691)\n",
+      "('FOR tau : ', 0.6022250809986659)\n",
+      "('PPR tau : ', 0.7933303940889317)\n",
+      "('NPR tau : ', 0.9547231923986377)\n",
+      "Tau: 0.50\n",
+      "('Training Accuracy: ', 0.7821521542016439, ', Training gamma: ', 0.8574042843302594)\n",
+      "('Accuracy : ', 3195, 14653, 0.7819559134648195)\n",
+      "('SR tau : ', 0.6765500013554587)\n",
+      "('FPR tau : ', 0.7134680978509129)\n",
+      "('FNR tau : ', 0.9827643852210782)\n",
+      "('TPR tau : ', 0.9875686745977381)\n",
+      "('TNR tau : ', 0.9467006553062615)\n",
+      "('AR tau : ', 0.920348482059736)\n",
+      "('FDR tau : ', 0.8263584179737061)\n",
+      "('FOR tau : ', 0.5143594749972882)\n",
+      "('PPR tau : ', 0.8266268964138297)\n",
+      "('NPR tau : ', 0.9242336242738334)\n",
+      "Tau: 0.60\n",
+      "('Training Accuracy: ', 0.7825323934598848, ', Training gamma: ', 0.8554832304502037)\n",
+      "('Accuracy : ', 3187, 14653, 0.7825018767487887)\n",
+      "('SR tau : ', 0.6801604075293094)\n",
+      "('FPR tau : ', 0.7195701276351641)\n",
+      "('FNR tau : ', 0.986495457298607)\n",
+      "('TPR tau : ', 0.9902334578535334)\n",
+      "('TNR tau : ', 0.9482780852625522)\n",
+      "('AR tau : ', 0.9211106754196199)\n",
+      "('FDR tau : ', 0.8237232744296363)\n",
+      "('FOR tau : ', 0.5134255457099633)\n",
+      "('PPR tau : ', 0.8244576911932922)\n",
+      "('NPR tau : ', 0.9239498336028926)\n",
+      "Tau: 0.70\n",
+      "('Training Accuracy: ', 0.7880019889438123, ', Training gamma: ', 0.8236660239606577)\n",
+      "('Accuracy : ', 3107, 14653, 0.7879615095884802)\n",
+      "('SR tau : ', 0.7388666842500354)\n",
+      "('FPR tau : ', 0.8125903372997396)\n",
+      "('FNR tau : ', 0.9463964707608775)\n",
+      "('TPR tau : ', 0.9586339909758471)\n",
+      "('TNR tau : ', 0.9693913785236763)\n",
+      "('AR tau : ', 0.9287326090184583)\n",
+      "('FDR tau : ', 0.7923873722053703)\n",
+      "('FOR tau : ', 0.4934019370460049)\n",
+      "('PPR tau : ', 0.7995087423891958)\n",
+      "('NPR tau : ', 0.9176068678992656)\n",
+      "Tau: 0.80\n",
+      "('Training Accuracy: ', 0.7888209658077159, ', Training gamma: ', 0.8466343589061862)\n",
+      "('Accuracy : ', 3085, 14653, 0.7894629086193954)\n",
+      "('SR tau : ', 0.6335828819141526)\n",
+      "('FPR tau : ', 0.6651902296035078)\n",
+      "('FNR tau : ', 0.9344431946006749)\n",
+      "('TPR tau : ', 0.9435242131376297)\n",
+      "('TNR tau : ', 0.9466027927717635)\n",
+      "('AR tau : ', 0.9175061708874659)\n",
+      "('FDR tau : ', 0.830043185477968)\n",
+      "('FOR tau : ', 0.5406237682301932)\n",
+      "('PPR tau : ', 0.8433187186542124)\n",
+      "('NPR tau : ', 0.924708780005249)\n",
+      "Tau: 0.90\n",
+      "('Training Accuracy: ', 0.7902249261458364, ', Training gamma: ', 0.8385275998938002)\n",
+      "('Accuracy : ', 3073, 14653, 0.7902818535453491)\n",
+      "('SR tau : ', 0.6393483420030692)\n",
+      "('FPR tau : ', 0.6752232647408157)\n",
+      "('FNR tau : ', 0.9397225346831646)\n",
+      "('TPR tau : ', 0.9478350033746951)\n",
+      "('TNR tau : ', 0.9489725581811307)\n",
+      "('AR tau : ', 0.9186356409377993)\n",
+      "('FDR tau : ', 0.8251506780512304)\n",
+      "('FOR tau : ', 0.5391870263914295)\n",
+      "('PPR tau : ', 0.8395321367866094)\n",
+      "('NPR tau : ', 0.9242720479007847)\n"
+     ]
+    }
+   ],
+   "source": [
+    "display(Markdown(\"#### Running the algorithm for different tau values\"))\n",
+    "\n",
+    "accuracies, false_discovery_rates, statistical_rates = [], [], []\n",
+    "s_attr = \"race\"\n",
+    "# Converting to form used by celisMeta.utils file\n",
+    "y_test = np.array([1 if y == [dataset_orig_train.favorable_label] else -1 for y in dataset_orig_test.labels])\n",
+    "x_control_test = pd.DataFrame(data=dataset_orig_test.features, columns=dataset_orig_test.feature_names)[s_attr]\n",
+    "\n",
+    "all_tau = np.linspace(0.1, 0.9, 9)\n",
+    "for tau in all_tau:\n",
+    "    print(\"Tau: %.2f\" % tau)\n",
+    "    debiased_model = MetaFairClassifer(tau=tau, sensitive_attr=s_attr)\n",
+    "    debiased_model.fit(dataset_orig_train)\n",
+    "    \n",
+    "    dataset_debiasing_test = debiased_model.predict(dataset_orig_test)\n",
+    "    predictions = dataset_debiasing_test.labels\n",
+    "    predictions = [1 if y == dataset_orig_train.favorable_label else -1 for y in predictions]\n",
+    "    \n",
+    "    acc, sr, fdr = getStats(y_test, predictions, x_control_test)\n",
+    "    \n",
+    "    ## Testing if constraint is satisfied\n",
+    "    assert fdr >= tau - 0.1\n",
+    "    \n",
+    "    accuracies.append(acc)\n",
+    "    false_discovery_rates.append(fdr)\n",
+    "    statistical_rates.append(sr)\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "### Plot of accuracy and output fairness vs input constraint (tau)"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "#### Output fairness is represented by $\\gamma_{fdr}$, which is the ratio of false discovery rate of different sensitive attribute values."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1cAAAHGCAYAAACYZ3E/AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAIABJREFUeJzs3XeYVFXSx/FvkSQpKhhQQcQccFEQAxgwp12MmMmiIuqu7mtYRV2zq6uCCSUKiIqoGFbFCCqIIoiYUJCMiGQkw3DeP6rHaYYJPTM9fbunf5/n6Wd6bt++XT3x1j116lgIARERERERESmbSlEHICIiIiIiUhEouRIREREREUkCJVciIiIiIiJJoORKREREREQkCZRciYiIiIiIJIGSKxERERERkSRQciUiIiIiIpIESq5ERERERESSQMmViEiMmY01sxB32z/qmCRxZjYq7nvXKOp4omJmM/P9HBd2mxl1rCIiFY2SKxERwMz2BI7Mt/myKGIRERGRzKTkSkTEXVrAtovNzFIeSQmYWfWoY5D0EkJoFEKw3Fu+xyzu1iiiEEVEKiwlVyIi7pLYxzXAi7H7uwPH5N/RzA41sxfMbJ6ZrTezRWb2sZm1KOE+f5ax5Tv+FtvNbGBcOdfRZjbczJYDP8Yev8DM3jezOWa22szWmdl0M+ttZjuV5D2Y2WNxr3V4vud9Fdu+1MxqFPbFLEk8+d7bUWY2JHb8xWb2ipntXMDxO5nZVDNba2Zfm9kphcVSSHzDzWyBmZ1RwGMvmdkUM6tWkmMm+LqPxr3XI/I99kVs+0oz29rM9jCzQWY2O/Y+l5nZd7Gv145JjKkk36uEf2ZFRLJSCEE33XTTLatvwBFAiN1eBU6N+7xPvn3PBjbEPR5/65DoPrH9RuVuz/caW2wHBsYdY1Hc/Zmxx3sX8noBmAJUS/Q9AI2BnNjnA+Ket3fcfk8W8zUtSTzx721pAft/kO/YHQrYZwPwe9znjYqJr0Usjo/ybT8h9vwTy+ln7eC4GHvGbd8zbvvA2Lbvi/gaHlSC1/zzeUn4XiX8M6ubbrrplo03jVyJiGxeEjgc+BBYFvv8PDPbCiA2UtMHqBJ77HZgJ6AecD4wPZF9khDvCnx+WA3g9Ni2ocDhsdepGnvNAbHH9s3dL5H4QgjTgTdjj19gZtvG7l8YF0OfYmJMKJ4CzMATjX3wZAngBDOrH4u/EnBv3P7tgG2AG4EdionpTyGEL4HngYNyt5lZVeAJ4OUQwgeJHqskQgiTgQmxT9uaWeXY/YvidutvZnWBA2Kf9wJqAdsDhwE9gOVJDKu03ysREclHyZWIZLXYCfUFsU/XAW+FEDaQl1xsC/w1dr8lUDd2f1QI4e4Qwu8hhMUhhOEhhE8S3KesbgshjAshrA0h/BDbNh+4BvgaWA0sADrGPWffErwHgEdjH2sA7WP3c79OE0IIk4qJMdF48rs9hDA9hDAV+DRu++5xz9sldv/rEMLgEMIfIYRHgTnFxJTfD8AOsUQG4Hpgt9hHAMysrZlNNrOJZnZ0/JPNLTGzhJO6mP6xjzsDrWP3c5OrabHvwVLyEvzTgH/hSc7aEMI9IYSSvteilPZ7JSIi+VQpfhcRkQrtVPyKPcBEoKF5D4tvyOsWeCk+ohU//+QHCpbIPsUp7m/z1/GfmFkd4DOgqHk4ufOjEoovhDDazL4GDgGuMLOPgANjD/ctKrgSxpPfT3H3V8Xdz23cUTdu29x8z50HNCgqtnymxD7ub96WvAfw7xDCXPDkCXgMOCaEMK2A5+8NrAghLIzfGHuehRA2FfK6Q4H/4u/pYjNbSN4oVX+AEMImM7sMeDr2OrfGHf874PRkJFhl/F7F0/mEiAgauRIRiS8JPBL4NnZ7OG77aWa2PX5FP1dha2Alsk+udbl3LNb1L3Zivkcxz1uT7/PW5J0cfwjUD94l7toyxtczbr/HY/dX48lBUUoST34b4u4X1BxhUdz93fI9tmsCx483FZ9btj8+UjcLT6Yws+3w5GtbYLiZ/Z+ZbWtmz5nZ92b2GV5GOT62/12xRhxv4k1GtmjC8eebCmEZMCL26Tn4HDJisTwXt99bQEN85OhvwF2xfQ4Cbivhey1MSb9Xpf2ZFRHJCkquRCRrmdk25JX8FaUaXhI3Blgc29bazP5lZjuY2XZmdpaZHZPgPrlmxd3PjeMa8sreErUx7v5aYJWZHRg7Vn4lie8F8pKxY2Mfh4UQViQxnpL6Gfg1dv8QM7ss1lnvH5Rs1IoQwnrgF6ArcB7QPVYSSghhKT5a9F4IoWkI4SF89HJSCOFAvCnI/xFLroBmeCJ0aQhhvxDCrxQttzSwDtA9dn9k/PPM7HG8wcZK4F3gFfKSm4Ylea9FKOn3Klk/syIiFZKSKxHJZueRV/I0LGy+BpABJ8fte2kIYQ1wOXknpPfiTReWAK8BjRPZJ+6Yz8fdH2Zmf+CjRflHpoozBsgtTTsDb3jxXUE7liS+WPLxVL5DFFkSWNJ4SipWandr3KZBseM/jM9TKqkfgebAiyGEj/M91hz4CiCWdO4Qm9tFrBRwAZsnV9eFEBJtNPEhMDt2P7ekrn++fa4C3sfLHdfjpao1Y4+NTPB1ilPS71WyfmZFRCokJVciks3iSwIHFfD4h/iJLcBRZtY4hPAa3lntRXwEZSOemIwmNocpkX1i+40GuuCjMevwUZTzgS9L8iZioyyn4XNnVsde807ggUL2Tyi+mKfJGy35MYQwJtnxlFQIYSDQGf96rcfLOM8BJpficNPwEZsbCnisGbHkCu/S9+f3JbbOVCNggpntBlQJIXy9xREKEUsSB8ZtWgS8kW+3B/Cv4e/492g1Pi/wWvJKNsukFD87SfmZFRGpqCwErfcnIiIFM7MD8KSlMj4y0yvikJLKzF4CGoQQjirgscXAfiGEhWbWDrga77Zo+AhOkxDC/mbWBrgyhHBaKmMXEZH0o5ErERHZgpmdbWY/450JK+Od+RIpCcw0zchbd+pPZtYYWBnXCXAYPoI0BR/hq8rmJYHj8x9DRESyj1qniohIQergLcDX4utNdQshrI42pOSKtSFvjJfabSa2kPLucZ+vpZDmJyGE28srRhERySwqCxQREREREUkClQWKiIiIiIgkQdaXBVaqVCnUqJHI4vMiIiIiIlKY1atXhxBCVg/eZH1yVaNGDVatWhV1GCIiIiIiGc3Msn7Nu6zOLEVERERERJJFyZWIiIiIiEgSKLkSERERERFJAiVXIiIiIiIiSaDkSkREREREJAmUXImIiIiIiCSBkisREREREZEkUHIlIiIiIiKSBEquREREREREkkDJlYiIiIiISBIouRIREREREUkCJVciIiIiIiJJoORKREREREQkCSJJrsysm5nNMLO1ZjbBzI4uYt+BZhYKuK3Kt9/VZvajma0xs5/MrF35vxMRERERERFXJdUvaGYXAD2BbsBnsY/vmNkBIYTZBTzlOuDmfNvGAJ/EHfMq4EHgcuALoAXQx8yWhhDeTP67EBEp3ooVsPXWYBZ1JCIiUqGEAGvXwqpVsHq1f6xVCxo2jDqyrGchhNS+oNkXwOQQwuVx26YCw0MItyTw/JZ4UtYyhDA2tm0s8EUI4R9x+/0XODyE0Kqo49WqVSusWrWqqF1ERErst99gv/2gc2f473+jjkZERFJu/XpPeuIToMI+T3Rb7uerV8OmTZu/XocOMGBAJG81l5mtDiHUijSIiKV05MrMqgHNgIfzPfQecFSCh7kc+D43sYrZClibb781QAszqxpC2FCaeEVESqt3b1i+HB55BNq0gWOOiToiERHZTE5OYolMaROgjRtLFk+1alCzpo9Axd/q1IFddtl8W0H77bVX+XydpERSXRZYD6gMLMi3fQFwYnFPNrM6QFsg/wjXSKCzmb0KfIUncF2AqrHXnJ/vOF2BrgDVqlUr8ZsQESnKunWeXB1/PMycCZ06wTff+P8+ERFJ0KZNsGZN+SVA69aVLJ5KlbZMaHITnXr1ik5+CkqG4rfVrAlVq5bP11FSKuVzrsroUrwJx+B82+8GdgbGAoYna88BNwL5xkwhhPAs8Cx4WWA5xisiWejll2HBAhg0yC9Etm4Nt94Kjz0WdWQiIim0YQMsWQKLFuXdFi/e/PMlS2DlyoIToDVrSv6ahSU19esnnugUtq1aNU2ilWKlOrlaBOQAO+XbvhPwWwLPvxx4JYSwJH5jCGEN0MnMrogdaz4+MvUHsLCsQYuIJCoE6NnT51uddJL/H776aujVC849F44utDeqiEga27ix+EQp/+fLlxd+vFq1fLRn++2hdu28kZ/SJj61akH16j66JBKhqBpafBNC6Bq37Wc8aSq0oYWZtcA7AbYOIYxK4HVGA/NCCBcXtZ8aWohIMn3+ORx1FDz5JHTr5ttWroQmTaBKFS8PrFkz2hhFJMvl5GyeKBWXJC1aBMuWFX683LK4evWgbt28+4Vtq1vXEyGpcNTQIpqywEeAwWb2Jd5S/UpgF6A3gJkNAggh5F+nqiswtaDEysz2AQ4HxgHbAdcDBwHty+ctiIgUrFcv2GYbaBf3F6x2bejf3+dg3XabN7kQEUmKnBxYujTxJGnxYt+/sIvr1avDDjvkJUGNGhWfONWokdK3LJLOUp5chRBeMrO6wG1AfeA74PQQwqzYLls06DezrYELgbsKOWxlPKHaF9gAfAwcFUKYmdzoRUQKN28eDB8O11zjCVW81q19JOuxx7w8sGXLaGIUkTS2aZMnPoUlRQV9vmRJ4YnSVlttnigdemjRo0n16mloXaSMUl4WmG5UFigiydKjB9x7L0ybBo0bb/l4bnlg1aowaZLOYUQqtE2bfM5RoklSbqKUf+2iXNWqbZ4oFVd2l5soqQGDpJDKApVcKbkSkaRYuxYaNoQjj4TXXy98v48+ghNOgOuv1+LCIhkpJwfGj4effio6cVq8uOhEqbjEKP/ntWopUZK0p+Qq81qxi4ikpRdfhIUL4dpri97v+OPhyivh0Ue9PPCoRJdPF5HozJ8PI0fCu+/Ce+956V6uqlU3T4QOPLD4RKl2bSVKIhWURq40ciUiZRQCNGvm61F+913x50x//AEHHeTzxidN0lxwkbSzfj2MGePJ1LvvwuTJvn3nneHUU/3WvLmX6W29tRIlkRiNXGnkSkSkzMaMga+/ht69EzvH2npr6NfP18G6/XZ46KHyj1FEijFjRl4y9dFHPkmyalVo1QoefNATqiZNlEiJSJE0cqWRKxEpo7Zt4YMPYM4cnxaRqCuugL594bPPfK6WiKTQ6tUwenReQvXzz769USM47TRPplq39qshIpIQjVwpuVJyJSJlMmcO7LGHN6j4z39K9twVK/xCeI0aPvKl8kCRchQC/Phj3typ0aO9lrd6dU+icsv99t5bo1MipaTkSmWBIiJl8vTTfs7WrVvJn7vNNj5ydfLJcMcdJU/ORKQYy5fDhx/mjU7NmePb99/ff2lPPRWOPlpXNkQkaTRypZErESmlNWugQQM45hh49dXSH6drV5+DNWYMHHFE8uITyTqbNnmXmNxkauxYb52+zTZw4olwyil+2333qCMVqZA0cqXkSsmViJRav37QpQt8/DEcd1zpj7NihXcPrFXLywOrV09aiCIV38KF8P77nkyNHAm//+7bDz00r9TviCO8OYWIlCslV0qulFyJSKmEAE2b+v1Jk8o+RWPkSD8HvOkmeOCBsscnUmFt3AhffJE3OjVhgv9C1q3ro1Knnuq1tjvtFHWkIllHyZWSKyVXIlIqo0f7aFXfvtC5c3KO2aULDBgAn38OLVok55giFcLcuXmNKN5/3+dSVarkI1K5o1OHHgqVK0cdqUhWU3Kl5ErJlYiUyrnnwqhRfs6XrLnwy5d7eeA22/jFeJUHStZat87XKMgdnfruO9++6655ydQJJ8B220Ubp4hsRsmVugWKiJTYzJkwYgTceGNym4zVqQN9+vgSO3fdBffdl7xji6S9adPykqmPP/Z1qKpV825+7dt7QnXggWqTLiJpTSNXGrkSkRK68UZ45BGYPh0aNkz+8Tt3hoEDYdw4OOyw5B9fJC2sXOnDv7kJ1S+/+PbGjfMW8T3uOKhdO8ooRaQENHKl5ErJlYiUyKpVsNtu3tX55ZfL5zWWLfPywDp1YOJE2Gqr8nkdkZQKAb7/Pi+Z+vRTWL8eatbcfBHfvfaKOlIRKSUlVyoLFBEpkeef9+TnuuvK7zW23RaefRbOOMPLA++9t/xeS6RcLV0KH3yQ14xi3jzfftBBcO213t2vVStNMBSRCkMjVxq5EpEEhQBNmvg0kAkTyn/qR8eOMHiwlwc2b16+ryWSFJs2+S9H7ujUuHG+rU4dOOkkH5k65RQf/hWRCkcjV0qulFyJSMI++sgblA0YAB06lP/rLV3qF/i33x6++krlgZKmFiyA997zZOq992DRIt/evHleqd/hh0MVFcuIVHRKrpRcKbkSkYS1aQNjx8KcOamrYvrf/+DMM+G22+Duu1PzmiJF2rDBF2PLLfWbONG377BD3iK+J50EO+4YbZwiknJKrpRcKbkSkYRMn+7z7P/1L7jnntS+docOMGQIfPmlr5MqknKzZ+eV+n34IaxY4Qv2HnVU3uhU06a+sK+IZC0lV0qulFyJSEJuuAF69fI1rnbdNbWvvXSpL+9Tr56XB1arltrXlyy0di188kleQvXjj769QYPNF/GtUyfaOEUkrSi5UnKl5EpEirVypc+/P+00eOGFaGJ4803429+gRw/vICiSVCHA1Kl5ydSoUbBmjWfyxx6bl1Dtv78W8RWRQim5UnKl5EpEivX009Ctm8+3OvLI6OJo1w6GDlV5oCTJH394l5bchGrmTN++9955ydSxx0KtrD5PEpESUHKl5ErJlYgUadMmL8mrXduTmigv2i9Z4rHsuCOMH6/yQCnCpk2wbp3f1q7Nu79sGXz8sSdTY8Z4c4patbzEL7dNeuPGUUcvIhkq0eTKzLoB/wfUB74H/h5C+LSI/S8GbgT2AVYAHwD/DCH8VsC+FwFDgf+FEM4s1RspA/VFFREpwgcfwJQpMGhQ9NVQ228PzzzjXQvvuw/uvDPaeCROCJ6o5CYx+ZOasm4r6fM2biw63oMPhn/8wxOqo45Sn38RSRkzuwDoCXQDPot9fMfMDgghzC5g/5bAYOCfwAhgJ+Ap4HnghHz7NgYeAgpN1MqbRq40ciUiRTjzTG8iMWtW+px/XnopvPSSj141bRp1NBHKyUle8lLWbevWeYKVDFWr+g/bVlt5z//c+0VtS3TfmjV9zalUd2URkayQyMiVmX0BTA4hXB63bSowPIRwSwH7/xO4JoSwe9y2jsDjIYTacduq4snaU0BroJ5GriKw/fbbM2rUqKjDEJE0NHduDf73v8Np334mn38+M+pw/tS2bRXefrsF5523nt69J1ClSgW/SLZoEfz2m5e6hZD3sazJTOXKnmzUrOktxM0K/1jUY8net7xNneo3EZHkq2JmX8V9/mwI4dncT8ysGtAMeDjf894DjirkmGOA+8zsr8BbQF3gQuDtfPvdC8wMITxnZq3L8B7KJOuTqyVLlnDcccdFHYaIpKG//90HEe6/vxH16zeKOpzNDBgAZ51VjbFjj+X226OOphzl5ECjRlCjhjdXKOmITiKjPFWy/l+hiEiybAwhNC/i8XpAZWBBvu0LgBMLekII4XMzuxAvA6yB5y/vA+1z9zGzk4G2QOT1HPqPIiJSgBUroH9/aNsW6tePOpottWkDF18Md9/t9//yl6gjKicffABz53odZNu2UUcjIiIpZmYHAI8DdwMj8SYYDwHPAO3MbAdgIHBRCGFZVHHmUnIlIlKA557zTtXXXht1JIXr1ctzjw4dvJNh1apRR1QO+vWDunU9gxQRkUy3CMjBm1LE2wnYovNfzC3AlyGEh2KfTzazVcCnZvYvYC884frQ8kqrKwGY2UbgwBDCT8l7C0WrlKoXEhHJFJs2weOP+7z/Fi2ijqZwdetC794waRI88EDU0ZSDRYtgxAjv4JEu3URERKTUQgjrgQnASfkeOgkYW8jTauIJWbzczysB44EmeElg7u0NvGNgU2BGmQMvAY1ciYjkM3Kkz/cfOjTqSIp39tlw4YV55YEHHxx1REk0ZIi3N+/cOepIREQkeR4BBpvZl3iziiuBXYDeAGY2CCCE0C62/5tAHzO7iryywMeAiXGt27+LfwEzWwZUCSFstj0VIhm5MrNuZjbDzNaa2QQzO7qIfQeaWSjgtirffheb2SQzW21mv5nZEDPbufzfjYhUNL16+Tyrc8+NOpLEPP44bLcddOzouUiFEIKXBDZvDk2aRB2NiIgkSQjhJeDvwG3AJKAVcHoIYVZsl4axW+7+A4Hrge54EjUc+BlIy3rxlK9zFVs4bAibLxzWEShs4bA6eGeQeGOAT0IIHWP7tAQ+YcvFxZaGEE6gCFrnSkTi/fQT7Lcf3HUX9OgRdTSJe/VVTwbvuQduvTXqaJJg/HivyXz6abjyyqijERGRBCSyzlVFF0VyVaKFwwp4fks8KWsZQhgb25bQ4mIFUXIlIvG6d4c+fWD2bNgp/3TbNHfhhZ5kTZwIBx0UdTRldOWVMGgQzJ8PdepEHY2IiCRAyVWKywLjFg57L99DRS0clt/lwPe5iVXMGKC+mf3VXD0KXlwsN46uZvaVmX21cePGkr0JEamwli+HgQM9Scm0xAq8PHDbbb17YEaXB65eDS+8AOedp8RKREQySqrnXBW1cFix86NiJYJtgT7x20MIn+PJ1PPAemAhYMQtLpZv/2dDCM1DCM2raPFIEYkZMABWrUrv9utF2WEHeOopmDABHnqo+P3T1vDhvtBYp05RRyIiIlIimdaK/VI85sHxG/MtLtYMOBVP1p5JdYAikplycnzkp2VLaNYs6mhK77zz4Pzz4c474buU90hKkv79Yc894dhjo45ERESkRFKdXJVm4bB4lwOvhBCW5Nv+5+JiIYTJIYSReKOMy8xst7IGLSIV3zvvwPTpmTtqFe+JJ7yarmNHyLjK52nTYPRoH7XKWwxSREQkI6Q0uSrlwmEAmFkL4C/kKwmMKW5xMRGRIvXsCbvu6utGZbodd4Qnn4SvvoKHH446mhLq3x8qVYL2BVZ1i4iIpLUoEo9HgA5m1sXM9jeznuRbOCx38bB8ugJTQwijCnjsTaCNmV1lZo1jHQV7sfniYiIiBfrhB/jgA+jWDapWjTqa5Gjb1ksE77jD319G2LjRO4qcdppnuiIiIhkm5clVSRcOAzCzrfGGFX0LOeZAMmhxMRFJL48/DlttBZdfXvy+meTJJ2HrrTOoPPDdd731uhpZiIhIhkr5OlfpRutciWS3pUtht928/Xq/flFHk3wvveTv7YEH4Kaboo6mGOecA599BnPnQrVqUUcjIiIlpHWuNB9JRLJc//6+rNI110QdSflo29ZzlttvT/PywAUL4M03oV07JVYiIpKxlFyJSNbKyfHOesccA02bRh1N+TDzta9q107z8sDBgz04lQSKiEgGU3IlIlnrzTdh5syK0X69KDvt5Enkl1/Co49GHU0BQvCazCOOgAMOiDoaERGRUlNyJSJZq1cvaNAA2mRB65sLL4SzzoIePWDKlKijyWfcOA+qc+eoIxERESkTJVcikpW+/RY+/hiuvhqqVIk6mvJnBk8/DbVqeXlgTv6VAaPUr58HdsEFUUciIiJSJkquRCQrPf441KhR8dqvF2Xnnf19jxsHjz0WdTQxK1d6S8O2bb1vvIiISAZTciUiWWfxYhgyBC69FLbfPupoUuuii7wM8rbb4Kefoo4GGDbMEyyVBIqISAWg5EoqhJwc6NoVnnsu6kgkE/TtC2vWVNz260XJLQ+sUSNNygP79YN994Wjjoo4EBERkbJTciUVwoMPQp8+cOWVMH161NFIOtu4EZ58Elq3hiZNoo4mGvXrezOPzz+Hnj0jDGTKFBg71tuvm0UYiIiISHIouZKM9+WXcMcdcPrpULUqdOvmnZ1FCvL66zBnTsVvv16cSy6Bv/4Vbr0Vfv45oiD694fKlX3hYBERkQrAQpafhdaqVSusWrUq6jCklP74Aw45xEcjJk3ydUivvRZeeMFbT4vkd+yxMHs2TJvm5/XZ7Ndf4cAD/TZ6dIq/Hhs2wG67wZFHwogRKXxhEREpL2a2OoRQK+o4oqSRK8lo114LM2Z4c4Jtt/VRq+bN4e9/h2XLoo5O0s2kSfDJJ9C9uxIrgF128bLAMWO8i2BK/e9/8PvvXhIoIiJSQSi5kow1bBgMHOhlTa1a+bbKleGZZ2DhQrjllkjDkzTUqxfUrKnz+XiXXQZnngn/+hdMnZrCF+7f33vDn356Cl9URESkfCm5kow0a5Z3BzziCLj99s0fO/RQuO466N3bJ+yLgCfcQ4f69J7ttos6mvRh5hckttrKk85Nm1LwovPnw9tvQ/v22bGCs4iIZA0lV5JxcnL8avumTfD88wWfm911l0/nuOIKn9oh0qcPrFuXne3Xi7PLLr6o8Gefpag88Lnn/BdZQ4giIlLBKLmSjHP//fDpp95Ou3HjgvepXRueeAK+/RYefTS18Un62bABnnoKTjoJDjgg6mjSU7t2XqF3yy3e7KPchOAlgUcfDfvsU44vJCIiknpKriSjjBsHd94JF10El15a9L5t2sBZZ/n+M2akIjpJV6+9BvPmqf16Uczg2WehWrVyLg/89FOf3KVRKxERqYDUil2t2DPGihXedj0nB775BurUKf45c+b4SMUxx8Bbb2md0mzVqhX89puv51RJl5SKNGCA5z29epVTCWWHDvDqqz7vqlZWd+sVEalw1IpdI1eSQa65BmbO9HlWiSRWAA0awN13+9z54cPLNTxJUxMmeKvx7t2VWCWiQwc47TS4+Wb45ZckH3zFCnj5ZV+ETomViIhUQDrVkIzw4oswaBDcdhu0bFmy53bv7h0Er70Wli8vn/gkffXq5efxHTtGHUlmyC0PrFIFOndOcnngiy/C6tV+YBERkQpIyZWkvVmz4Mor4cgjoUePkj+/ShVvNf37774mlmSPBQv8fL5Dh8RHO8U7bT76KIwe7Y1AkqZJQNtHAAAgAElEQVRfPzjwQGjRIokHFRERSR9KriStbdzojSuKarueiObNfQTrqafgiy+SG6Okr2efhfXr1X69NDp2hFNOgZtugunTk3DA776DL7/0CV2a/CgiIhWUkitJa/ff72vvPPUU7LFH2Y51992+ns8VV3jSJhXb+vXw9NNw6qmw775RR5N5zHxtsMqVk1Qe2L8/VK3qi9SJiIhUUEquJG19/jn8+99w8cXFt11PxDbb+Pybb76Bnj3LfjxJb8OHe0M6tV8vvQYN4JFHYNQo6N27DAdavx4GD4a//Q122CFZ4YmIiKQdtWJXK/a0tGIFNG3q641OmpS8+TIh+PpXH34IP/wAu++enONK+jniCFiyBKZMUZfAsgjBywPHjvVFuUs1gjx8OJx/vrftPO20pMcoIiLpQa3YNXIlaap7d29kMWRIchsRmMETT/jH7t39xFEqni++8Ns11yixKisz6NvXv46lLg/s1w923RVOPjnp8YmIiKQTnXZI2nnhBa8g6tGj5G3XE9GwoZcbvvUWvPZa8o8v0Xv8cdh6a+8SKGXXsCH897/w8cfeJKRE5syBkSP9m1G5cnmEJyIikjZUFqiywLQycyb85S9w0EHeBrq03QGLs3GjdxBcuBB+/NHnY0nFMH++l3t26waPPRZ1NBVHCD7wNG6clwc2apTgE++5x6+U/PILNG5cniGKiEjEVBaokStJI7lt18HLAcsrsQI/9rPP+on4bbeV3+tI6j3zjP8sde8edSQVS255IHh5YELX5TZt8i6BrVsrsRIRkayg5ErSxn33wZgxyWm7nogWLXx044knYPz48n89KX/r1nn79dNPh732ijqaimf33eHhh+GjjxIsDxw1CmbM8GxMREQkC6gsUGWBaeHzz+Hoo+HCC33UKlWWL4f994edd/b1TctztEzK3+DB0K6dT/FR74TyEQKceKL/vnz3XTEdNy+91Cc3zp8PNWqkLEYREYmGygIjGrkys25mNsPM1prZBDM7uoh9B5pZKOC2qiT7SPpasQIuucTX1HnyydS+dp06vvbV1197EwTJXCH4+mX77QcnnRR1NBWXmTf/CwG6dCmiPHDZMnjlFV+oTomViIhkiZQnV2Z2AdATuA84BBgLvGNmDQt5ynVA/Xy36cCwEu4jaerqq2H2bHj++eS2XU/Uued6GVmPHt7YTDLTuHEwYYIvGmwWdTQVW6NG8NBD8MEHefOwtjB0KKxdq5JAERHJKikvCzSzL4DJIYTL47ZNBYaHEG5J4Pktgc+AliGEsaXdJ5fKAqM1dKiPWt15J9xxR3RxzJwJBxzgpWQjRkQXh5TeRRfBO+/A3LlQu3bU0VR8mzb5COH48V4e2DD/5bFmzSAnx4eFle2KiGQFlQWmeOTKzKoBzYD38j30HnBUgoe5HPi+mKQpkX0kYjNmwFVX+VpWt94abSyNGvnaV6+/ruQqE82bB8OH+yCJEqvUqFTJR602bSqgPHDSJJg4ETp1UmIlIiJZJdVlgfWAysCCfNsXADsX92QzqwO0BfqUcZ+uZvaVmX21cePGROKWJEtl2/VE/f3v0KQJXHMN/PFH1NFISTz9tA+SXH111JFklz32gP/8B95/3+dh/al/f6hWzYelRUREskimtWK/FI95cFn2CSE8G0JoHkJoXiUdzuqz0L33wtixflKc8GKk5axqVV8jad48uP32qKORRK1d69+3v/5VSylF4cor4bjj4Prrfe4ka9f6FZOzz4a6daMOT0REJKVSnVwtAnKAnfJt3wn4LYHnXw68EkJYUsZ9JEJjx8Jdd/nI1cUXRx3N5o480k8We/XyqiZJfy++CIsWwXXXRR1JdqpUyUetcnKga1cIr42ApUvVyEJERLJSVA0tvgkhdI3b9jOeEBXa0MLMWgBfAK1DCKNKu09+amiRWsuXQ9OmPg1j0iTYZpuoI9rSsmW+9tWuu8IXX0DlylFHJIUJwfsmrF8P336r6T1ReuIJL6ntt//DdFr1uE+qrJRpxREiIlIWamgRTVngI0AHM+tiZvubWU9gF6A3gJkNMrNBBTyvKzC1mKQpkX0kQldf7e3On38+PRMrgG23hcce87beqV53S0pmzBhvRqf269Hr1g2OPXwt//jxcuaee50SKxERyUop/+8XQngJ+DtwGzAJaAWcHkKYFdulYez2JzPbGrgQKGxFlYT2kWg9/7zfbr/dy+/SWdu2cOqp3sVw7tyoo5HC9OwJ222nvgnpoFIl6NfiGTZSha5fX1X44sIiIiIVWMrLAtONygJTY8YM+Mtf4OCDYdSo9OgOWJzp0+HAA32B4VdeiToayW/2bG9gcf313rFOIpaTA40b83iNG7n2p6vp3x86dow6KBERSSWVBWZet0DJQBs3+siCWfq0XU9E48a+sPGrr8Ibb0QdjeT39NM+50rt19PEhx/C7NlcfUc9jj4a/vEPjfqKiEj20ciVRq7K3Z13+gK9Q4fCRRdFHU3JbNgAhx7qjTh++EEL1KaLNWtgt928BbhGFdPEhRfCe+/Br78ybW51Dj4YWreGt97SfDgRkWyhkSuNXEk5GzMG7r4bLrss8xIryFv7as4cTxIlPQwdCkuWeCMLSQOLF8Nrr/n6CtWrs9decP/98PbbMKig9kQiIiIVlJIrKTfLl3s5YKNG3qY5Ux11lK/f89hj3plOohWCN7I4+GA45piooxHAO9WsX7/Z2lbXXAOtWvn6Y/PmRRibiIikHTPrZmYzzGytmU0ws6OL2f9iM5tkZqvN7DczG2JmO8c9fr6ZfWVmy8xsVWzf9uX/Trak5ErKTbduPucinduuJ+qBB6BuXbjiCp+3L9EZPdrXtFL79TQRgq8i3KyZd62JqVQJ+vf3nOuKK1D3QBERAcDMLgB6AvcBhwBjgXfMrGEh+7cEBgPPAQcCZwEHAM/H7bYYuAc4AjgYGAD0M7PTy+ltFErJlZSLIUO8dOuOO+CII6KOpuy22w4efRTGj4fevaOOJrv16uWJ7sUXRx2JAL4g3OTJm41a5dp7b7jvPvjf//xvgohIvBC8M68uvmSd64GBIYQ+IYQfQwjXAPOBqwrZ/0hgbgjh0RDCjBDCOOBx4PDcHUIIH4UQRoQQpoQQfgkh9AQmA0WOiJUHJVeSdNOn+6hVq1bwr39FHU3yXHQRnHQS3HIL/Ppr1NFkp5kz4fXXvUyzRo2ooxHAh6eqVy90UuU110DLlj7SqN8bEYn3+uuw555+Ieb++/U3IhuYWTWgGfBevofeA44q5GljgPpm9ldz9fC1bd8u5DXMzE4A9gU+SU7kicv6boENGjQIgwcPjjqMCiMnx7juuqbMnFmLvn3Hs/PO66IOKanmzatOp06HceSRi7nzzh+iDifr9O7dmJdfbsALL4xjxx0r1s9WRgoBvvkG6tSBPfYodLc5c2rQpUtzmjVbyr33fqdyThEB4I47DuSbb+rQqNFqvvlmWypVChx++GJOP/03jjhiMVWqZPc5aiZq3br1euDbuE3PhhCezf3EzHYB5gHHhhA+idt+O3BJCGHfgo5rZucAA4EaQBXgfaBNCGFN3D51YsfeCsgBrg4h9EvSW0tYhqw4VH6WLFnCcccdF3UYFcYdd8D338MLL8CFFx4ZdTjlYuZMuO22HVm1akfOOCPqaLLHqlVw9tlw7rnQtm3F/NnKOEOG+IJWH33kffGLsHAh3HBDPebNO45LL01NeCKSvlauhC+/hC5d4PHHqzFtGvTvbwwcWI8ePeqx007Qvj106gT7Fni6LWlqYwiheTIPaGYH4GWAdwMjgfrAQ8AzQLu4Xf8AmgK1gROAR8xsZgjhw2TGU2y82T5ypXWukuezz+DYY70b83PPRR1N+Vm/Hpo2hdWrPZGsldWrOaTOM8/AlVfCp596yamkgdatYfZsmDrVO1gUIScHjj4apkzx35v69VMUo4ikpZde8uXxRo/evPPrxo3wzjveJ+ett/xvR6tWnoSdd57+56a74ta5ipUFrgYuCiG8HLf9SeCgEMKxBTxnMFA7hHB23LZWwKdAgxBCgUvWm1lfYI8QwgmlfkOloDlXkhTLlnlSlelt1xNRrZqf6M+a5YsjS/kLwRtZHHKIz9+RNPDLLzBqlF9WLiaxAqhcGQYM8IsSV16pCewi2W7YML/Ikv9vepUq8Ne/wogRvsbkAw/AggXQoYPvf8UVPuKlvyGZKYSwHpgAnJTvoZPwroEFqYmX+cXL/byof0CV8BLBlFJyJWUWQl7b9aFDYeuto46o/B19tDdHe+QRb5Qm5eujj+CHH9R+Pa0MGOBJVfvElxHZd1+45x544w0vHRaR7PTHH77I+Hnn+YWXwtSvDzfdBD/9BJ98AuecA4MHw+GH+8oPPXv6GuaScR4BOphZFzPb38x6ArsAvQHMbJCZxS9B/ybQxsyuMrPGsdbsvYCJIYTZsefcamYnxh7f38xuAC4DUt6rVmWBKgsss8GDoV07uPtuuO22qKNJnSVLYL/9oHFjGDs2oYv3Ukpt2sDnn3sFWvXqUUcj5OTA7rv7Ss5vF9isqcintmoFP//s5YE771z8c0SkYnnhBV9OozRl3suXw4svetng+PFeTXLWWX7B88QT9b84asWVBcbt1w24EZ8/9R3wj9wGF2Y2CiCEcFzc/tcAVwJ7AMuBj4CbcksCzex+4DxgN2ANMAV4PISQ8kt5Sq6UXJXJ9Ok+/6hpU/j446KvQFVEQ4bAZZfBU0/BVYWtziBlMn067LUX3HqrJ/CSBt5+G844A4YP9w4jJTRliv/NOO00ePVVjUaKZJuzz/bSvjlzypYMTZ7sSdaQIX7Bc/fdoWNHvzUscDlaKW+JJlcVmfJ7KbUNG+CSS/wP45Ah2ZdYgb//E07wta/mz486morpiSf8Z+vKK6OORP7Urx/Uq+cTI0phv/08UR4xwq9Ai0j2+OMPb1hx3nllH2U6+GAvDZw3z/+W7LMP3Hmnz/8+5RR4+WVYp1U7JMWUXEmp3X03jBvnzR2y9QqRmY9arV3rHakluVau9PP4886DXXeNOhoBvKf6G2/4kG21aqU+zPXX+7yJ7t19srqIZIc33/SEp23b5B2zenW44AJ47z2YMQN69IAff/TX2HVX///83XfJez2Roii5klL59FO4916fy37BBVFHE6199vGStZdegnffjTqaimXQIFixwhtZSJoYPNh7JXfuXKbD5HYPXLXKS2qzvEJdJGsMG+YJz5HltFxho0beyXfGDB8ha90annwSmjSBI46APn189EykvGjOleZcldiyZd6lp2pV+Prr7OgOWJx16/xrsn69Xx2rWTPqiDLfpk1w4IH+8/XFF5qXkxZCgIMO8m/KuHFJOeSDD8LNN3tJT7ZfqBGp6FasgB128A7Djz6autdduNCnL/Tr5410atb0Ua0uXeCoo/T/JZk050ojV1JCIfhV5nnz4PnnlVjl2morL4+cMUNNF5Llgw+88YHar6eRL77wnvhlHLWKd8MNcNhhcPXV8PvvSTusiKShN97wi5Dnn5/a191hBy8N/PZb7zx78cXej6dVK9h/f3joIZUnS/Jo5EojVyUyaJCXAt5zj5fCyeY6dfKqqa+/9gv8UnpnnAETJvhizVulfAlAKVDXrn5VZf582GabpB32hx98gei//c0noItIxdSmDUyc6H/Xo26ZvnKllyj26+fLqeQuXty5szfDqFIl2vgylUaulFwpuSqBX37x9smHHuqLumZjd8DiLFrkndD23dfnpUX9zyNTTZ3qc9nuuMM7P0kaWLXKV/Q85xwYODDph3/gAe+6+dJLyZ3oLiLpYfly2HFHH6V+5JGoo9ncjz9C//7w3HNeQrjLLt7OvVMnX8tSEqfkSmWBkqDctutVqvjIjBKrgtWrB//9r18F69s36mgy1xNP+Jw+tV9PIy+/7LPAk1gSGO+f/4TmzVUeKFJR5ZYEpuPFk9zSwLlz4ZVX/ELy/ffDnnvC8cf7gP2aNVFHKZlCI1cauUpIjx5eCqirysULwf8YT5rkc4Z22inqiDLLihWw225ePjJ4cNTRyJ+OPtqznilTym0S3HffQbNm/r0fNqxcXkJEIvLXv/qivzNnZsY82rlzfSSrXz+fT73ttn6RuXNnL2OWgmnkSiNXkoBPP4X77oMOHZRYJcIMeveG1at9LR8pmeee8wEStV9PIz/9BJ995jUy5XhWdNBBXgr68suaeyVSkSxbBiNH+pqFmZBYgV/ku/VWmDYNPvwQTj/dK1IOPdRvTz3l70skP41caeSqSGq7Xnp33ulrbYwcCSefHHU0mWHTJp+zVreud3SSNHHzzfDwwzBnjs+7KkcbN/paNLNne8vkHXYo15cTkRTIbYY1bpwvHp6pli71EsF+/bw6pXp1OPdcH8069ljNswaNXIGSKyVXRQgBLrrI64/HjIEWLaKOKLOsXeuJ6caNXu5Uo0bUEaW/t9/2LoFDh/rPnqSBjRuhQQPvl/7GGyl5yW+/9fLAc87x9a9EJLOdeab/XmdKSWAiJk70kayhQ71ZR+PGnmS1b++LJGcrJVcqC5QiDBrkc6z+/W8lVqVRvbqXB06fDvfeG3U0maFXLx8YOffcqCORP739Nvz2W7k1sihIkyZw++3+9+eVV1L2siJSDpYuhffe82kFFSWxgrzSwF9/9fnBDRt6GWHDhp5MjhjhzcAk+2jkSiNXBZo2zSdsNmvmtcbqDlh67dvDCy94WeWBB0YdTfqaMsU7Nt11lzdQkTTRpo0vHjxnjtcHp8iGDV4eOHeulwfWq5eylxaRJBo40Nuaf/mlD4BXZNOmeUv3gQN9OcCddoJ27fza1L77Rh1damjkSsmVkqsCbNjgq5b//LN39mnQIOqIMtvChT6P6IADYPRo1WQXpnt36NPHz+F33DHqaATwEavddoMbboAHH0z5y0+e7O3Zzz3XL1CISOY54wxfKHz69Io1clWUjRvh3Xe9bPCttyAnB1q2hC5d4PzzoVYFTj2UXKksUArw73/7FaZnn1VilQw77ODrZ3z2GQwYEHU06Wn5cr/Sd9FFSqzSyqBBflbQsWMkL3/wwT6K+eKLMHx4JCGISBnklgSef372JFbga4LmlgbOnevXphYu9D+l9etD165+npXl4xsVlkauNHK1mU8+geOO87br/ftHHU3FEYJ/Xb/91svflEBs7tFHvW39V195KaqkgRB8yHWHHfzKQEQ2bPA5n5Mm+cWeFi28tOiww3xUa5ttIgtNRIoxYICv4DB+vP++ZrMQvDlY376+1MTq1b78ROfOcOmlFaf0WSNXESVXZtYN+D+gPvA98PcQwqeF7DsQaF/AQ5t988ysGnAbcBmwC7AAeDiE0KuoWJRc5Vm61LvbbbWVzw+qXTvqiCqWH3/0r+8FF2hx3Hg5ObDPPn41L8JzeMnvs8984eD+/SMbucq1YIG3Px4/3q/2Tp/u2818HkNuwtWiRd7fMBGJ3mmn+TJ5v/ySXSNXxVmxwkfk+/b1v2vVqvn01i5d4MQTM3v6gJKrCJIrM7sAGAJ0Az6LfewIHBBCmF3A/nWA/E2sxwCfhBA6xu33KrAbcCswFdgJqBFCGFVUPEquXAhw4YXw6qswdmzFn3QalR494J574IMP4IQToo4mPbz5Jvztb94ZTotUp5GOHb0Wb/78tLvSsnixn5DkJlvjx3sCBt5z4y9/yUu2DjvMB+DUlEcktZYs8YYON9wADzwQdTTp69tvfd2swYP9a9awof/57dgRdt896uhKTslVNMnVF8DkEMLlcdumAsNDCLck8PyWeFLWMoQwNrbtZOBlYM8QwqKSxKPkyuV287nvPril2O+ClNaaNT6PBPwPavXq0caTDk46yUslp09PaTM6Kcoff8DOO/skuL59o46mWCH4vIbcROvLL73E9I8//PHatb3cND7h2n13XUkXKU/9+3vJm8q9E7NuHbz+uv/J/eAD33bSSf41bNMmc0bklVylOLmKle6tBi4KIbwct/1J4KAQwrEJHGMg0DyEcFDctqeAfYAvgXbAGuAd4F8hhJVFHU/JlbcObdrU66HVdr38ffCB/8Hs0cPbjmezH37w9vRK6tNM375w+eU+jH3kkVFHUyqbNnk5Uvzo1qRJsH69P77DDpsnW4cd5ttEJDlOPRWmTvVzDF3IKJlZs3y+Wv/+3kG3bl247DJPtA46qPjnR0nJVeqTq12AecCxIYRP4rbfDlwSQihyFYBYieB84JYQQs+47e8CxwEfAncB2wKP4yNk5xVwnK5AV4Bq1ao1W7duXRnfWebasMHbg06bBt98o+6AqXLppTBsmLea3m+/qKOJzlVX+T+QuXMrzmTeCuHII72F4/ffV6izovXr/XcuPuH64Ye8jl2NGm2ebDVrlnYVkSIZYfFiLwn8v/+D+++POprMlZPjF2T79ctblLhFC0+yLrwwPRv6KLnKvOTqauC/wC4hhCVx298DjgZ2DiEsj207GRgZ27agsGNm+8jVrbf6qMHLL8N5W6ShUl5+/92TqiZNYNSoCnX+mrClS30JpQsv9H8ckiZyhxMfftgnS1Rwf/wBEyduXlI4a5Y/VqmSL2wd3zCjSROffC4ihcsd/J44EQ45JOpoKoZFi2DIEP/afv891Kzp85Q7d/aL5OlyHqHkKsPKAs1sEvB9COGSfNufw+dg7RW3rQEwG2gRQhhf2DGzObkaPRpat/a5Vjq5Tb3cfz5p0IwtEg8/7Fc1v/7ay1IlTfzzn9CzJ8ybl7VrBvz+u88TiU+4FsVm8261lf+8xpcU7rNPZnf3Ekm2k0/2ebRTp6bPSX9FEYL/TerXzxdXX7nSu6Z26gTt2/uIYZSUXEXX0OKbEELXuG0/A68U1dDCzFoAXwCt83cAjJX5PQbsmDvHysxOAD4Adgoh/F7YcbM1uVq61Bsr1KjhV5ZU+pJ6mzbBMcd4M4cpU7KrLC4nB/bc05sKjB4ddTTyp/XrfTixVStvHSqAn8zMmrV5sjVhAuT+69hmG5+zGp9w7babTiolOy1a5P1wbrzRK2Ok/Kxc6ZVH/fr5GlrnnAOvvBJtTEquomvFPhhvwT4GuBLoDBwYQphlZoMAQgjt8j2vL3BMCGGfAo5ZG/gRGAfcic+5egb4MYRwflHxZGNyFYKvtfTaa2q7HrXvv/er4Jdc4h0bs8WIEXD22f5P4Jxzoo5G/vTqq3DuufDWW3DGGVFHk9ZycvyiSHzCNXmyz4kAP7nMnbuVm3Btv320MYukQp8+0LWrqhJSbcoU/7t04IHRxqHkKtpFhG/EFxH+DvhH7hwsMxsFEEI4Lm7/rfFGFneFEP5TyDH3xZtYtAKWAiOAm0MIfxQVSzYmV7krpt9/P9x8c9TRSO68t48+8jLNbHD88b6o5C+/QJUqUUcjfzrjDG+pN2uWvjGlsHatNwaKb5gxZUre43vuuXmydeihPm9CpCI56ST/E/LTTxq9zUZKrhJNrsy2IoQK2VIv25KrqVN9culhh3kHGrVdj96aNd5atUoVv/KdKWtZlNbkyb7I64MPetmIpIl583z1yptvhnvvjTqaCmP5ci8hjE+45szxxypX9qvM8R0KDzpI671J5lq40Edtb7kF7rkn6mgkCkquINFLk79i9jzQlxAml2dAUn42bPDys2rVfCVwJVbpoUYNeOopXxPkgQfgjjuijqh8Pf64v+cuXaKORDbz3HM+ETAbu6uUozp1fKT2+OPztv322+bJ1iuv5K3VXL26XwCL71C4114aAZDM8Oqr/mfk/CInZIhUbImOXG0CcnecAPQBXqCYBXozQTaNXP3rX14KOHy4T6uQ9HLxxX6SNXmyd/6piBYv9on+l10Gzz4bdTTyp02bvOXdbrv52gCSUiF4Z7XcZGv8eB/tWrPGH9922y3nb+2yS7QxixTkxBN9ZHbKFF0QyFYauUo8ufoKODRuS8Bbqr8E9COEz8sluhTIluRq1Ci/ctqpU94VUkkvv/3ma18deih8+GHF/Mf04INedfbtt+m/ynxWGTXKJ/wNGuSZr0Ru40Zfciy+Yca33/qEdfDkKn50q3lzT8JEovL771C/vl/IvfvuqKORqCi5KklDC7O9gAuBC4DcXiS5T/4ReBpPtNYmOcZylQ3J1ZIlPsdFbdfT3zPPwJVXeoVWu3bF759JNm6Exo1h7709eZQ0ctll8MYbMH++OiyksdWrvd9I7ujWl1/6PNpc++yz+ehW06b+d18kFXr3hquu8uqLJk2ijkaiouSqtN0CzQ7CO/PlLvqbe5A5wOmE8ENSokuBip5cheAreI8YAZ9/7lc3JX1t2uRLDE2d6mUVdetGHVHyDB/udfgjRkCbNlFHI39avtxnoHfoAE8/HXU0UkJLl/qCx/FzuH791R+rUsVPcuMTrgMOUCNIKR/HH+/XZ374oWJWXkhilFyVNLky2wZoD1wB7J+7FViHN8eoDIwmhIxpKF3Rk6v+/aFzZ2+UcNNNUUcjifj2Wy8NbNfOFwasKI45xmvxp01TM5W0knu5+csvtehdBTFv3uajW+PHew4NXjr4/vu60CbJtWCBl6reeivcdVfU0UiUlFwlPufqMHyx3wuAGnhCBbAAeAovCdwRmAjkkEFf1IqcXOW2XW/RwtuuV6oUdUSSqJtv9vlJo0bBsccWu3va+/prTxgffhhuuCHqaGQzhx0G69b5Ak263FwhbdrkFzXGj4drr4UTToBhw6KOSiqSp5+Gbt00n1aUXEHJuwXm/uf9GuiJdwzcELffz8CehJAx16UranK1fj20bOmLtE6e7E3AJHOsXu3r31Sv7nMsMn3tq06d4KWXYO5c2G67qKORP+UuOvbYY3DddVFHIylw/fW+HMLcubDTTlFHIxVF69Y+evX997pGk+2UXEFJxjIC8DpwHCE0I4RBmyVW7kagU9Kik1K74w6vw+/bV4lVJqpZ09e+mjIFHnoo6mjKZuFCGDoU2rJJPFkAACAASURBVLdXYpV2+vXzhe8uvTTqSCRFunb15jIDBkQdiVQUv/0Go0f7/G4lViKJj1w9CvQihBnlHlGKVcSRq48/9rKPzp2hT5+oo5GyuOACeP11L7XYe++ooymd++7zOvzvv/fJ9JIm1q3zSRInnujDipI1WreG2bO9dFzl4lJWTz4J3bvDd995xYVkN41clbZbYAVS0ZKrJUvg4IOhVi1vu14rq3+8M9/8+b721WGH+ST0TLsquGED7LGHJ1XvvRd1NLKZYcM8e3/3XTjllKijkRR68UW46CIYORJOPjnqaCTTHXssLFrkF9BElFwlWhZo9hBm0zH7Z77t/4xt/095BCclE4KXfPz+u5dhKbHKfPXrw/33+7pQQ4dGHU3Jvfqqdy679tqoI5Et9OsHDRr4yJVklbPPhnr1vFGkSFnMnw+ffuolgSLiEi0IaAPsDryVb/sbQKPY4xKx/v3hlVfgnnugWbOoo5FkueIKOPxw+Mc/fGQyk/TqBXvuCaefHnUksplZs3wotGNH9cXPQltt5d/6N97IWxNLpDReecUv7J5/ftSRiKSPRJOr3JYIM/Ntnx372CAp0Uip/fyzjw4cfzz885/F7y+Zo3JleOYZT6wyaa2yr76CsWPhmms0ryPtPPecnxF17Bh1JBKRrl0hJ8cvyomU1rBh3npd82lF8iR6yrMx9rFJvu1N8j0uEVi/Hi6+2Nt2DxqkE9mK6C9/8ZGrvn3hs8+ijiYxjz8OtWtDhw5RRyKb2bTJW8WdcAI0ahR1NBKRvfbyH4E+fTzJEimpefP8/5FGrUQ2l+hp+E+xj/0xa4VZXcxaAX1j26ckPzRJ1O23w4QJfuK9665RRyPl5c47oWFDLxNcvz7qaIq2YIFPmu/QAerUiToa2cxHH8HMmd5OVLLaFVd418CRI6OORDKRSgJFCpZocvUivoDwAcBo4PfYxyb4+lcvlkt0UqyPP4b//Acuv9wnKUvFVauWt7z94Qd4+OGooynaM894Ati9e9SRyBb69fMFx/QHI+u1aQM77ui/ryIl9fLL0KQJ7L9/1JGIpJdEk6tewFg8wYq/AYyJPS4ptngxXHYZ7LMPPPpo1NFIKpx5Jpx7Ltx9N/zyS9TRFGz9enj6aTj1VNh336ijkc0sWQKvvQaXXOJ1xJLVqlWDTp3grbdg7tyoo5FMklsSqC6BIltKLLkKYQNwAnAznkxNi328CTiJEDTnKsXUdj179ewJVatCt27+c5Buhg+H335T+/W0NHSoLx6skkCJufxyn4bXr1/UkUgmGT7cP6okUGRLWkQ4QxcR7tvX/yn+5z/wf/8XdTSSak884V34hg71xUDTyRFHwNKl8OOPaq6Sdg45xFeinjgx6kgkjZx6qi8AO2MGVKkSdTSSCVq2hJUr4Ztvoo5E0o0WEU68LNCZbYvZYZgds8VNUuann+C667zT0w03RB2NROGqq6B5c+8guHRp1NHk+eILv6n9ehqaOBEmTdKolWzhiiu8LPCdd6KORDLB3Lm+zIZKAkUKltjpj1lVzPoBC4FxwMf5bh+VV4Cyufi26889pxPYbFW5Mjz7LCxcCLfcEnU0eXr1gq23hvbto45EttCvn68ee/HFUUciaebMM6F+fTW2kMSoJFCkaImemv8T6AhUZsumFvHNLaSc3XabX4Du109t17PdIYfA3//uJ0Rjx0YdDfz6qy8o2amTJ1iSRtas8RrSc8/1ToEicapW9QHNt9+GWbOijkbS3bBh0LSpN9MSkS0lmlxdiLdcnxT7PACvAmvx5hbPJT80ye/DD+Ghh7yRxVlnRR2NpIN//xsaNPCyng0boo3lmWd8MVK1X09Dr70Gy5Z55itSgC5d/GPfvkXvJ9lt9mz4/HOVBIoUJdHkas/Yx/P+3BLCecD5wB7Am8kNS/JbvBjatfPW1o88EnU0ki5q1/bmFt99F+3Pxbp10Ls3nHEG7LVXdHFIIfr1gz32gNato45E0tTuu8Npp/mPStQXaiR9qSRQpHiJJldVYx9nATkAmNUAPsBLBf+d9MjkTyH4VcWFC+GFF9R2XTb3t7/5erD//rd3+4rCsGG+LIDar6eh6dPho4+gY0dN0pQiXXEFzJ/v616JFOTll70kXRfRRAqX6H/a3H5kNYAlsfs9gNxedfo1K0d9+sCIEXDfff5HTSS/Xr28yUUUa1+F4Gtv7b8/nHhial9bEjBwoLdf79Ah6kgkzZ1+us/lVWMLKcisWTBunEoCpeIyw8zYuazHSTS5mh77uCswEW9gcRNwNz7/KqLr5RXflCnetODEE+H666OORtLVbrvBPffAu+/6lcVU+vxzmDDB26+bWtukl5wcGDAATjnFJ+eJFKFKFa+SeO+96EbBJX2pJFCSycy6mdkMM1trZhPM7Ohi9r/YzCaZ2Woz+83MhpjZznGPX25mn5rZUjNbZmYfm1mrksQUAoEkdEBPNLl6H/gZ2A94GNjE5l0C7yprILKldeu8a3LNmmq7LsXr3h2aNfM10JYvT93r9uoFderAZZel7jUlQe+/74vSqJGFJKhLF79I0qdP1JFIuhk2zP/H7Lln8fuKFMXMLgB6AvcBhwBjgXfMrGEh+7cEBuMN9A4EzgIOAJ6P2+044CXgeOBw4CdgpJntXcLwpplRpp7HiZ2uh3AHIexPCK8TwofAMfgX5b/AMYTwUlmCkILddht8/bVPMN7l/9m77zip6uv/468jTUBEilJEgyUqRZSADRQrhkiwgAiiohBhFWM0iSbxpybGGPNNNMYSE0RBhIiyIDaCASWiIAICIggoqIAVEAsqvZzfH5/ZMCxbZndn5k55Px+Peaxz586ds9dhZ879nM/5NI86Gsl01aqFcp61a+H//b/0vObHH4ermVdeGZprSIYZPhwaNQoT80QS0KJFaEwzYoQaW8guK1fCnDkatZKk+QUw0t0fdvel7n4t8BlwdSn7nwR87O5/c/cV7j4LeICQRAHg7pe4+9/d/U13fzd2rG+BbhWMbT3wvBntKvpLFale7h5mtYB/Esr/7sT9fdxnErLMrNewYUOmTZsWdRh7mDevAXfffQw9enxK/frLyMAQJUNdcMHh/POfB9KmzXxat/42pa81fPgh7Nx5MB06zGbatM0pfS2poO3b4aST4LzzQu2mSII6dWrI88+34847F3PqqZ9HHY5kgLFjDwIO46CDZulvvZSnupnNjbs/zN2HFd0xs5pAB0IlXLwpQKdSjvkacKeZ9QAmAo0Iy0RNKiOOmsDe7OobkagPgAbAZDOqAW8Ab7hzW6IHME9k9rvZRqAWsA/umyoYZEarW7eub9iwIeowdrNuHbRrF0qt5s0LZYEiifr229BcolEjmDs3LBCaCps3h2k8nTuHhiuSYe69F37+c1i0CNq2jToaySI7dsChh4ZFYl98MepoJBMcf3xoXvTGG1FHIpnOzDa6e6l9rc2sOfAJcKq7vxq3/bfAJe5+ZCnP6wmMJDTXq06YsnSel5KXmNldwMVAa3f/pvy4aeTOF8W2HUhIBDu487vyjlEk0Vk8RYsH75/ogctSkUlsZjbSzLyE24a4fU4rZZ+jkhFvOhW1XV+3DsaMUWIlFVevHjzwACxcGLr4pcoTT4T3qdqvZyD3UBJ4/PFKrKTCqlWDQYPgpZfgvfeijkaitmJFSKrUJVCiYmatCWWAfyAkO92ApkCJvU3N7DqgAOiZSGIVs8yMD8wYa8YvzegCrHfnuYokVpB4cvUrYAswFLMmFXmB4io6iQ24DmhW7PYBUFjCvm2K7be8KrFGYdgwePZZ+NOf1HZdKu/888M0m9/9LrTPTTb30MiiTRutS5uR3ngjrCytRhZSSQMHhiRr2LDy95XcVtSBVvOtJEnWEdbMLZ5PNAFWl/Kcm4A57n6Xuy9098nAEOAyM2sRv6OZXQ/cAZzj7nMSDcqdRsAPgbeAW4BhwOdmLDbj0USPA4knV6MIJ+KHwKeYfYbZB3G39yvwmhWaxObu6919ddENOAw4FCipl9Ha+H3dfUcF4orc0qWhiqdr1/BTpLLMwuiVGVxzTfLXvpoxAxYsCKNWar+egYYPh9q1oW/fqCORLNW8ebhA8+ijoXOt5K/CQjjuOGjZMupIJBe4+1ZgHtC12ENdKb2fQx1CHhKv6P7/chkz+wVhdKu7u8+oeGwsJ4yKfd+do4DvAYuBfStynESTq5aEXwxC+/UmsW3xt3LFTWKbUuyhsiaxFTcIWOyhqUZxc83sMzObamalXk83s8FmNtfM5m7fvj3Bl02t+LbrI0eq7bpU3cEHw+23w7//DRMmJPfY998PDRrApZcm97iSBBs3hprN3r3DxE2RSiooCKW/Tz8ddSQSlQ8+CHO/VRIoSXYPcIWZXWlmrczsPqA5MBTAzEaZ2ai4/Z8HzjOzq83s0Fhr9vuB+e7+Yew5NwL/B/wEWGZmTWO3in4QNnRnHYA7a4FL2HOUrUyJfoX/MO62qoTbhwkepzFQDVhTbPsaKH9F5NgJuog9R62KRr56AT0Jve2nljaXy92HuXtHd+9YvXr5DRPT4eabw0jAiBFquy7J87OfwbHHhp/fJFp1XI4PPwxftgYN0pzAjDR+fOhq8pOfRB2JZLmuXeGQQ8ISD5KfVBIoqeBhCafrCeV3C4CTCWV8RRMZDo7divYfSah8+ynwNjCesP7ueXGHvQaoQVjr6rO4W0Vnn881I342+U7ggIocILFugUlS2Q4hcftdQ1hbq7m7f1nOvpOA7e5e5gIvmdAt8MUX4eyz4aqr4J//jDQUyUFvvAEnnBAWGb7//qof7ze/gbvuClc0v/e9qh9PkuzUU+HTT2HZMtVsSpX96U9h3bx33oEjy/yEllzUoUPoODtrVtSRSLYor1tgpjKjszuvmVGfkLw1BuYA7YC17rslcmVKd/FZZSaxxRsEPFVeYhUzG6joqsxpt24dXH55aJ39179GHY3kouOOC/Ou/v73qrfR3bgRHn44NMxQYpWBli+HV18N3QiUWEkSDBgA1aursUU+eu89mD9fo1aSN4pGuK50pyuhod67wD8IVXMJS6wmzqx/ufu4jyp/F99qZkWT2MbFPdQVeKrsEOx44BjCMGIijiUMB2a0qVPh669h0iSVWEnq3HFHmHc1eHBIsCpbDTtmDHz5pdqvZ6wRI8KEzcsvjzoSyRFNm4aLKSNHwh//CHvvHXVEki5FJYEXXhhtHCJpUsOMQwlzrP7qzqvAq+U8p0SJLiK8EyhrR8c9oa9rsVbsowktFF8DriJMPmvj7quKJrC5e/9iz3sE6OLuR5RwzOuBlYSOHjWBS4HfAL3cvcyp/JlQFrhmDTSpUoN7kfI99VT4kLznnsp1o3SHY44J393ffFMDIxln+/bQxaRDB3j++aijkRzy0kth/tW//gWXXBJ1NJIuP/gB1KoFr78edSSSTbK4LPAi4G9AfUKjvbmx27ziiwuXpyJlgVbOLSEVncQGYGb1gL7AI6UctiZwF7AQmB47ZvfyEqtMocRK0qFnT+jeHW69NTSlqKhXXoFFi9R+PWP95z/w2WdqZCFJd8YZcPjhamyRT5YvDxfR1CVQcpnZrgo+dwqBFsDHwONAPeAG4F0zVlTouAmOXBWvMalOWGvqJ0Bd4Fe4Z2UrhkwYuRJJl5Urw8K/Z50VFquuiAsugOnT4aOPwhJKkmEuuABmzoSPPw4z0EWS6K674Fe/CmtTt2kTdTSSanfeGboYf/ghHHRQ1NFINsmmkSszlgDXuPNy3Lb93Pm62H6HuCeeYCU2cuX+WLHbcNxvBk4hrH91SKIvKCLRadkSfv97eO45eOaZxJ+3YkV4zuDBSqwy0po1MHEi9O+vxEpS4ooroGZNNbbIF4WFcNJJSqwk5y0CXjLjCTOaAxRPrGLbKjRyVdVuge8BGwmTv0QkC1x3HbRrF1qzf/ttYs/5xz9CKeDVV6c2Nqmk0aPDnCuVBEqK7L9/KC0eNQo2bYo6GkmlZcvgrbdUEii5z50+wNmEhnlLzfiFGdWqetzEkiuz/iXcBgPPEMoC96lqICKSHjVqhLkTn34a5l+VZ8MGeOSR8MVKVzEzkDsMHw6dOsFRR0UdjeSwgoLQ3bawMOpIJJXUJVDyiTtTCWtZ3Qn8HlhgRpeqHDNZ3QL/i3vXqgQSFc25knx1zTUwdCjMmRMazJXmoYfCAtczZkDnzumLTxI0c2b4H/PIIxq5kpRyD2syNmwY3naSm445BurVC3/zRSoqm+ZcFWfGgcC9QE/gCeCX7qyp6HGS0S3wfeCair6wiETrzjvhgAPCPKrt20vexx3uvz+05O3UKb3xSYKGD4e6dVXDIylnFv5evP566Bwqueedd2DhQv05kfxjRgPge8B/gHlAP+ADM2aYcZ8Z5a/5G5NocjWghFs/oDPQCvdlFYhfRDJA/fpw330wfz48+GDJ+0ydCkuWqP16xvr2Wxg7Fvr0CZeaRVLs8svD2kdqy56bikoCe/WKNg6RdDDjR2a8ZMZqYB0wAxgK7As8C/yD0Jr9HGBEwsdNqCwwh6ksUPKZe1j7avp0WLoUWrTY/fFzz4VZs0I73r33jiZGKcOIEaEU8LXXNLQoaXPppWGd6k8/DYOmkjvatQsX3qZPjzoSyVbZVBYYS6q+IqxrtQR4B1juzrYS9t3XnW8SOW6iDS0OwawLZq2KbW8V265W7CJZyCyMWu3YEUan4r3/fujuXVCgxCpjDR8emlicdFLUkUgeKSiAb74Jg6aSO5YuDeWeKgmUPDId6O/OHe5McGdJSYkVQKKJFSReFvgg8DJwfLHtHWPb/57oC4pIZjnkEPjd7+Dpp8NaVkUefBCqVVP79Yy1dGnoKjBwoGo2Ja1OPhlat1ZpYK4ZNy78KVFJoOQLd3q780ayj5tot8DVwP5AM9zXxm3fH1gDrMG9WbKDSweVBYrAtm2hacX69WGOFcCBB4aSwTFjoo1NSnHjjXDvvfDxx9CkSdTRSJ65//6wZt78+dC+fdTRSDK0bQuNGsErr0QdiWSzbCoLTJVER64axH5uLrZ9a+xnw+SEIyJRKFr76qOPwijWY4+Fsp/ipYKSIbZtC6u5/vjHSqwkEpddFsqFNXqVG5YsgcWLoXfvqCMRyX6JJldfxX4W/2fXq9jjIpKlOnUKcynuvTe0aT/uODjhhKijkhL9+9+wdq3WtZLINGgQmlQ+/nhoWinZTSWBIsmTaHI1i7Cm1T8wG47ZLzF7BPgnYXHhWakKUETS509/gv33D13A1H49gw0fDs2aQbduUUcieaygAL77Dp54IupIpKoKC6FLl/BnRUSqJtHk6j5CElUduAL4C2Gtqxqx7X9LRXAikl4NGoTv7d27qzwkY336KUyaFBYcql496mgkj514Ihx9tEoDs93ixaEsUF0CRZIjseTK/WXgemAbYQSr6LYV+Dnumv4okiO6dw8t2GvVijoSKdFjj8HOnaFLoEiEzMLo1fz5MHdu1NFIZRUWwl57Qc+eUUcikhsqtoiw2YFAN6AJoUvgf3D/JDWhpYe6BYpI1nCHI46A5s3V0ksywvr14e3Yrx88/HDU0UhFuYe2+k2bwssvRx2N5AJ1C0y8LDBw/wT34bjfGfuZ1YmViEhWmT4d3ntPjSwkY9SvD337hnlX3yS8xKZkisWL4Z13VBIokkyJJVdmN2L2X8yuLrb96tj2X6YiOBERiTN8ONSrp5ZeklEKCmDDhtA5ULKLSgJFki/RRYTfBloBHXF/M257O2ABsAT3timKMaVUFigiWWH9+tDK67LL1EFAMop7WITcHd58U11Gs4U7tGoVFoyfOjXqaCRXqCww8bLAlrGfS4ttXxb7+b2kRCMiIiUbOxY2bVJJoGQcM7jqKnjrLZg9O+poJFGLFsG776ozrEiyJZpcFV2HOqTY9kMreBwREamM4cOhbduwurNIhunXD/bZR4Oq2UQlgSKpkWhS9H7s5z8xawEQ+/lgscdFRCTZ3n4b5swJo1aquZIMVK9eSLDGjoWvv446GimPO4wbB6efDgccEHU0Irkl0eTqGcLo1SnAKsy+BVYBXQiLCE9ITXgiIsLw4VCjBlx6adSRiJSqoCBUro4eHXUkUp6FC2HZMnUJFEmFRBta7APMBY4o4dF3geNw/y65oaWHGlqISEbbsiXMOD/99HCpWSSDHXdcSLAWLdIgaya7+Wb485/hs89g//2jjkZyiRpaJDpyFRKnzsBQ4BNge+znP2LbG6coPhGR/Pb88/DFF2pkIVmhoCCsnTRzZtSRSGncw3yr009XYiWSCok3onD/AvchuB+Ee02gHfA28CzwXoriExHJb8OHQ4sW0LVr1JGIlKtv3zD/So0tMteCBWEtcpUEiqRGxbr8mdXArCdmE4BPCQ0tOrOrm6CIiCTLRx/B5MlwxRVQrVrU0YiUa599wtTAwkL48suoo5GSjBsX/pxccEHUkYjkpsSSK7NTMHsIWA2MA84DarErqfokJdGJiOSzkSNDDc+AAVFHIpKwgoIwVXDUqKgjkeKKSgLPPBMaa0KHSEqU3tDC7EjgMqAfuxYJLj5C5cAPgakk1Bkj86ihhYhkpJ074fDD4ZBDYOrUqKMRqZATT4T162HJEjW2yCTz50OHDvDII5rGKamhhhZlj1wtBW4CWhKSKgO+BkYDN/xvL/eXsjWxEhHJWNOmwYoV+gYkWemqq+Cdd+DVV6OOROIVFoaSwPPPjzoSkdyVSFmgA08A3YADcL8cmJzSqERE8t3w4bDffpoYIVnpoougfn01tsgkRSWBZ50FjRpFHY1I7kq0ocV5wGCgV2zNqyoxsyFmtsLMNpvZPDM7pYx9R5qZl3ArsZbPzE42s+1m9nZV4xQRicRXX8FTT0G/flC7dtTRiFRYnTrQv394G69bF3U0AqEkcMUKdQkUSbWykqtZ7CoHrANcAIwB1gKVvhZlZn2A+4A7gfbATOAFMzu4lKdcBzQrdvsAKCzh2A2AUYAmKIhI9hozJnQEUEmgZLGCAti6NfRlkegVFkL16ioJFEm10htaAJgdyq6mFt+Pe8QJSZcDY4HRuL+Q0AuazQYWuvuguG3LgfHuflMCz+8MzAA6u/vMYo9NAN6KxXahu7ct73hqaCEiGadDh9DQ4s03o45EpEpOPhnWroV331Vjiyi5w6GHQqtWMGlS1NFILlNDi/LKAt0/wP33uB8JnERY12odu3cN7AM8n8iLmVlNoAMwpdhDU4BOCcY8CFhcQmI1BGgC3JHgcUREMs+CBaF+R6NWkgMKCmD5cnj55agjyW9z58LKldC7d9SRiOS+xBcRdp+N+7VAc+BcQlneZnaVDiaiMVANWFNs+xqgaXlPNrP6wEXAw8W2Hw38DrjU3XckcJzBZjbXzOZu3749wdBFRNJg+HCoVSvMtxLJchdeCA0aqLFF1AoLoUYNlQSKpEPiyVUR9+24T8S9LyEhuhKYluS4SnMpIebRRRvMrBahNPEGd1+RyEHcfZi7d3T3jtWrV09NpCIiFbV5Mzz+eOgQ2LBh1NGIVFnt2nD55fD006E8UNLPHcaNg65dQ6IrIqlV8eQqnvu3uI/A/cwEn7EO2EEo34vXBFidwPMHAU+5+5dx25oBrYBHY10CtwO/BdrE7p+dYGwiItF65pnQKVAlgZJDBg+Gbdvg0UejjiQ/vfEGrFqlLoEi6VK15KqC3H0rMA/oWuyhroSugaUys+OBYyhWEgh8AhwNHBt3Gwq8F/vvMo8rIpIxhg+Hli3hjDOijkQkaVq1gi5dYNiw0KdF0quoJPC886KORCQ/pDW5irkHuMLMrjSzVmZ2H2Ee11AAMxtlZqNKeN5gYLm7T4vf6O7b3P3t+BuhXfyW2P3vUvvriIgkwcqV8NJLMGAA7BXFn2aR1CkogA8+gKlaKCWtikoCzz47rEkuIqmX9k9wdx8LXA/cAiwATgbOcfdVsV0Ojt3+x8zqAX2BR9IYqohI+jz6aOhVfcUVUUciknS9ekHjxjB0aNSR5Jc5c+DDD1USKJJOZa9zlQe0zpWIRG7HDjjkkFA/NXly1NGIpMSNN8Lf/gYffQTNmkUdTX745S/h73+HNWs0ciXpoXWuoikLFBGReFOnhm+camQhOWzw4HAdYcSIqCPJDzt3hpLAH/5QiZVIOim5EhGJ2vDhofW6ZpxLDvv+90OvlocfDkmWpNbs2eGajRYOFkkvJVciIlH64ovQgv3SS8PiwSI5rKAgtAWfMiXqSHJfYSHUrAnnnht1JCL5RcmViEiU/vUv2LpVJYGSF84/Hw44AB56KOpIctvOnTB+PHTrBvXrRx2NSH5RciUiEhX3UBLYsSO0axd1NCIpV7NmWG1g4kT45JOoo8lds2bBxx+rS6BIFJRciYhEZd48WLRIo1aSVwYNCnOuhg+POpLcVVgYqox79Ig6EpH8o+RKRCQqw4fD3nvDxRdHHYlI2hx2GHTtCo88osYWqVDUJbBbN9h336ijEck/Sq5ERKKwcSOMGQMXXqhJEZJ3CgpCJ7sXXog6ktwzcyZ8+qlKAiWzmdkQM1thZpvNbJ6ZnVLO/v3MbIGZbTSz1Wb2LzNrGvd4GzMbb2YfmJmb2W0p/yVKoeRKRCQKEybAN9+oJFDy0rnnQtOmMHRo1JHknnHjVBIomc3M+gD3AXcC7YGZwAtmdnAp+3cGRgOPAW2A84HWwONxu9UBVgK3ACtSFXsilFyJiERh+PBQH3XqqVFHIpJ2NWqE6wovvAAffhh1NLmjqCTwnHOgXr2ooxEp1S+Ake7+sLsvdfdrgc+Aq0vZ/yTgY3f/m7uvcPdZwAPACUU7uPsb7n6Du48BNqb6FyhL9ShfPBM0bNiQadOmRR2GiOSTLVvgxz+GAw+EV16JOhqRSLRtWwv3E7nlllUMHLgy6nBywsKF9fnss/a0bbuEadPWRh2O5KfqZjY37v4wdx9WdMfMagIdgLuLPW8K0KmUhoGWogAAIABJREFUY74G3GlmPYCJQCOgLzApaVEnkbl71DFEqm7dur5hw4aowxCRfHLzzfB//xcu2R94YNTRiETmnHPgrbfCwsLV8/5yb9Vde21oFPL557DPPlFHI/nIzDa6e90yHm8OfAKc6u6vxm3/LXCJux9ZyvN6AiOB2oTBoReB89x9Uwn7vg2Md/fbqvCrVJrKAkVE0mn7dhg5MrTyUmIlea6gIDRfmDgx6kiy344dYeHgc85RYiW5xcxaE8oA/0AY9eoGNAUycjlyJVciIuk0ZUr4NqlGFiJ07x6uMTyUkV+Rsstrr8Hq1eoSKBlvHbADaFJsexNgdSnPuQmY4+53uftCd58MDAEuM7MWqQu1cpRciYik0/DhsP/+Yc6VSJ6rXj1cZ5g8GVaujDqa7FZYCLVrh4RVJFO5+1ZgHtC12ENdCV0DS1KHkJDFK7qfcblMxgUkIpKz1q6F556D/v2hZs2ooxHJCFdeCWbw8MNRR5K9ikoCu3dXSaBkhXuAK8zsSjNrZWb3Ac2BoQBmNsrMRsXt/zxwnpldbWaHxlqz3w/Md/cPY8+paWbHmtmxwN5A09j9w9P6m6FugSIi6TN6dJhzNXBg1JGIZIyDDgrzhEaMgNtuC23apWKmT4c1a6B376gjESmfu481s0aENamaAW8D57j7qtguBxfbf6SZ1QN+CvwVWA/8F/h13G7NgTfj7h8GFACvAKel4NcolboFqlugiKSDO7RtC/vuC6+/HnU0Ihll4sSw6O348dCrV9TRZJ8hQ0KfnM8/h7ql9mkTSb3yugXmA5UFioikw+zZsGSJGlmIlOBHPwojWEOHRh1J9tmxA556KkzjVGIlEj0lVyIi6TB8ePjm06dP1JGIZJxq1WDQIHjpJXjvvaijyS6vvhqmc6pLoEhmUHIlIpJq330HTz4Zvv3Uqxd1NCIZ6Sc/CUmWGltUTGEh1KkT5q2JSPSUXImIpNq4cSHBUiMLkVI1bx7mXT36KGzdGnU02WH79l0lgXXqRB2NiICSKxGR1BsxAo48Ejp3jjoSkYxWUBCaMjz9dNSRZIdXXgnnSyWBIplDyZWISCq9+y7MmBFGrcyijkYko519NrRsCQ89FHUk2WHcuDCV80c/ijoSESmi5EpEJJVGjAgTSfr3jzoSkYy3116hscXLL8OyZVFHk9mKSgJ79FBJoEgmUXIlIpIq27bBY49B9+7QtGnU0YhkhYEDoXp1GDYs6kgy27RpsG6dFg4WyTRKrkREUuWFF2DNGq1tJVIBTZvCeeeFRXE3b446msxVWKiSQJFMpORKRCQVtmwJE0eaNlWPZJEKKiiAL76ACROijiQzbd8ezs2550Lt2lFHIyLxqkcdgIhI1vvuO3jrLZg/H958M9wWLw5lgTffHGqcRCRhZ54Jhx4KQ4dCv35RR5N5Xn45JJ/qEiiSefSJLyJSEV98sSuBKkqmli0D9/D4/vvDD34A3bpBhw5w/vnRxiuShfbaK4xe/frXsGQJtG4ddUSZpbAQ9tkn/JkRkcxiXvSFIE/VrVvXN2zYEHUYIpJp3OHTT3cfjZo/Hz78cNc+Bx8M7duHZKroZ/PmarkukgRr10KLFjBkCNx7b9TRZI5t20K1cbdu8PjjUUcjsjsz2+judaOOI0pKrpRcicjOnfDBB7uPRs2fH1bnhJAsHXHE7olU+/bQqFG0cYvkuL59YfLkcJ1Dc4uCyZNDYvXMM6Hxh0gmUXIVUVmgmQ0BbgSaAYuB6919ein7jgQuL+Gh//3PM7NTgT8BRwJ1gFXAI+5+d/KjF5Gstn07LF26eyK1YAF88014vHp1aNsWfvzjXcnUMceEGhwRSauCAhg7NiyWq6XignHjoF49+OEPo45EREqS9pErM+sD/AsYAsyI/RwAtHb3D0vYvz5Q/HrVa8Cr7j4gtk8H4PvAImAj0Bl4CLjR3f9RVjwauRLJYZs3w6JFu49GLVq0q79z7dohcYov62vTBmrVijZuEQFCde5RR0HjxvDaa1FHE71t26BJk7B03ujRUUcjsieNXEWTXM0GFrr7oLhty4Hx7n5TAs/vTEjKOrv7zDL2mwBscfeLyzqekiuRHPHNN2EEKn6O1JIlsGNHeHy//fYs6zvySKhWLdq4RaRMf/0r3HBDuC7Stm3U0UTrP/8J61o99xz06BF1NCJ7UnKV5rJAM6sJdACKl+tNAToleJhBwOJyEqv2sePdVsrjg4HBADVr1kzwZUUkY6xdu2fHvvfe2/V406YhiTr33F3JVMuWajQhkoUuvxz+3/8Ly8Y98EDU0USrsBD23RfOPjvqSESkNGkduTKz5sAnwKnu/mrc9t8Cl7j7keU8vz7wGXCTu99XwuMfA/sTksbfu/vt5cWkkSuRDOYOH320e1nfm2/CJ5/s2ueQQ3YfjWrfHpo1iy5mEUm6Sy6Bf/87NLaoUyfqaKKxdWsoCezRA0aNijoakZJp5Cr71rm6FNgLKK3S+BRgH+BE4M9mtsLdVZUskg127oTly/fs2Pfll+HxvfYKky9OO21XMnXssdCgQaRhi0jqFRTAmDGhucWAAVFHE42pU+Hrr7VwsEimS/fIVU1Cw4mL3X1c3PYHgbbufmo5z19AKAm8JIHXugUY4O6HlbWfRq5EIrB1a5gPVbxjX9G/xZo14eijd58j1a5d/l6yFslz7qHXTL16MHt21NFEY8AAePppWLNGPXckc2nkKs0jV+6+1czmAV2BcXEPdQWeKuu5ZnY8cAxwfYIvtxegPz8iUdu4ERYu3H006u23Q4IFULduSJ4GDtyVTLVqFRIsERHCdMnBg+HnPw/XYY49NuqI0mvr1pBYnX++EiuRTBdFWeA9wGgzm0NoqX4V0BwYCmBmowDcvfiKFoOB5e4+rfgBzexaYAXwbmxTF+AGoMw27CKSZF99tWfHvnfeCSV/EBbdbd8err9+VyJ1+OGh5E9EpAz9+8NNN4XGFv/8Z9TRpNeLL8L69dC7d9SRiEh50p5cuftYM2sE3EJYRPht4Bx3XxXb5eDizzGzekBfoLQGFdWAPwMtge3A+8BviCVsIpICn322Z8e+FSt2Pd6iRUigevfe1WjioIPUsU9EKqVhwzDf6PHH4a678mtd78JCqF8funaNOhIRKU/a17nKNJpzJVIOd1i5cs+OfatX79rn8MN3X4i3fXvYf//IQhaR3DRzJnTuDMOGwaBB5e+fC7ZsCV0CL7gAHn006mhEyqY5V0qulFyJFPftt2GFyvjSvq+/Do9VqwatW+/e+vzYY8PCKyIiKeYeetvUqgVz50YdTXpMnBjar0+aFBYQFslkSq6yrxW7iKTS00/DtdeGdaT23jt8i+nTZ1cydfTRYbuISATMQlv2a6+FefOgQ4eoI0q9wsKw4sSZZ0YdiYgkQiNXGrkSCQv1XnstPPssHHMM3H8/dOoE1XX9RUQyy9dfQ/PmcOmloTwwl23eHEoCe/WCESOijkakfBq5Cu3KRSRf7dgREqnWrWHKFPjLX+CNN6BLFyVWIpKR9tsP+vYNiwp/803U0aTWlCnhd9TCwSLZQ8mVSL5asABOOgmuuw5OPhkWL4Ybb4QaNaKOTESkTAUFYc3xMWOijiS1xo1TSaBItlFyJZJvNmwISVTHjrBqFTzxRJgpfcghUUcmIpKQ448PFcxDh4YmF7lo8+ZQqd2zp655iWQTJVci+WTSJGjTBu6+GwYODAv89u2rtadEJKsUNbZ46y2YMyfqaFJj8uTQvFULB4tkFyVXIvlg9erQ9a97d6hTB6ZPDzPBGzSIOjIRkUq55BKoWxceeijqSFKjsDAsnHzGGVFHIiIVoeRKJJft3Bm+eRx1VKgvuf32sG7VySdHHZmISJXsuy/06wdPPrlrKb5csWlTWG5QJYEi2UfJlUiuWrw4dP276qqwTtXChXDrrWH1TRGRHFBQEBKRf/0r6kiSa/Jk+O47dQkUyUZKrkRyzaZNcMstYdHfd96BkSNh6lQ44oioIxMRSaoOHcLtoYdyq7FFYSE0agSnnx51JCJSUUquRHLJ1KnQrh388Y9w8cUhubr8cjWsEJGcVVAAb78Nr78edSTJEV8SqOUGRbKPkiuRXLBuXUiizjor3H/pJXjsMWjcONq4RERS7OKLoV693Gls8cILYcUMlQSKZCclVyLZzD2U/R11VFhN8+abw9wqrTgpInlin31C58DCQvjqq6ijqbrCwnBd7LTToo5ERCpDyZVItlq2LCRRAwbAkUfCggVwxx1Qu3bUkYmIpFVBQVh0d9SoqCOpmo0bYeJE6NVLJYEi2UrJlUi22boV/vCHMLdq/nwYOjSsW9WmTdSRiYhE4thj4fjjs7+xhUoCRbKfkiuRbDJjRvgW8dvfwnnnwdKl4ZLtXvqnLCL5raAg/EmcPj3qSCqvsBD23z+soiEi2UnfyESywVdfweDBcMopoW7k3/+GsWOhWbOoIxMRyQh9+oSFhbO1sYVKAkVyg5IrkUzmDk8+Ca1awYgRcMMNYXHgc86JOjIRkYxSty707w/jx4cGqtlm0qSQYKkkUCS7KbkSyVQrVoQk6uKL4aCDYO5cuOuu8A1CRET2UFAQpqU+9ljUkVRcYSEccIBKAkWynZIrkUyzbRv85S+hQcWMGXDffTBrVphrJSIipWrbFjp1gmHDsquxxYYNoSTwwguhWrWooxGRqlByJZJJ5syBjh3h17+Gs8+GJUvgZz/Tp62ISIIKCsJKFdOmRR1J4v79b9i0CXr3jjoSEakqJVcimeCbb+Daa+HEE+GLL2DCBHjmmVAOKCIiCevdGxo0yK7GFoWF0KRJ6FkkItlNyZVI1J5+Glq3hgcfhGuuCaNVF1wQdVQiIlmpdu3Q2GLCBFi7Nupoyvfdd6GZhUoCRXKDkiuRqHz0EZx/PvTsCY0aweuvwwMPhF7CIiJSaQUFYfrqyJFRR1K+opJAdQkUyQ1KrkTSbccOuP/+MFo1ZQr8+c+hE+AJJ0QdmYhITmjVKpTYDRsGO3dGHU3ZCgvDkoWdO0cdiYgkg5IrkXRasABOOgmuuw5OPjmsWfWrX0GNGlFHJiKSUwoK4P33YerUqCMp3bffhpLAXr1UEiiSK5RciaTDhg1w442hE+CqVfDEE+ET9ZBDoo5MRCQn9eoVKq4zubHFxImwebNKAkVyiZIrkVSbNCmsWXX33TBwILzzDvTtC2ZRRyYikrP23huuuAKefRZWr446mpKNG6eSQJFco+RKJFVWr4Y+faB7d6hTB159NUwAaNAg6shERPLC4MGwfTuMGBF1JHsqKgns3Rv20rcxyTNmNsTMVpjZZjObZ2ZlLkRgZv3MbIGZbTSz1Wb2LzNrWmyfXma2xMy2xH5G0npZ/5xFkm3nzlCHctRR4ZLp7bfDm29qARMRkTQ74gg4/XR4+OHMa2zx/POwZYsWDpb8Y2Z9gPuAO4H2wEzgBTM7uJT9OwOjgceANsD5QGvg8bh9TgLGxrYdG/s5zszS3i0skuSqItmqmY00My/htiFun55mNsXMPjezb81stpmdm57fRiTO4sXQpQtcdRX84AewcCHceivUqhV1ZCIieamgAFauDM1ZM0lhITRvDp06RR2JSNr9Ahjp7g+7+1J3vxb4DLi6lP1PAj5297+5+wp3nwU8AMQnTtcDL7v7H2PH/CMwLbY9rdKeXFU0WwWuA5oVu30AFMbtcyrwX6B77JiTgKfLG2IUSZpNm+CWW6B9e1i6FB59NLSoOuKIqCMTEclrF1wA+++fWY0tvvkG/vMflQRK/jGzmkAHoPjljilAaZcaXgOamVkPCxoDfQnf94ucVMIxJ5dxzJSpnu4XJC5bjd2/1sy6EbLVm4rv7O7rgfVF92NDg4cCl8Xtc12xp/3ezLoThg2nlxVMw4YNmTZtWiV+DZGYb78NHQAbNAhzqlq0gOrV4ZVXoo5MRESAM888lMLCgxg//nUaN94adTi8+OIBbNnSmsMPn8+0ad9EHY5IMlU3s7lx94e5+7C4+42BasCaYs9bA5xV0gHd/XUz60so9atNyF9eBC6P261pKcdsSpqlNbmKy1bvLvZQWdlqcYOAxe4+s5z96gFflXewL7/8ktNOOy3BlxaJs24d/PKXMGoUHH44DB0KZ54ZdVQiIlJMixbw5JOwdGknbr016mjgb38LMQ0Z8gONXEmu2e7uHZN5QDNrTSgD/ANhNKoZcBfwENA/ma+VDOn+J11WtlpuZmlm9YGLgIfL2e8aoAVh8ltJjw82s7lmNnf79u2JxC2yizuMHBkaVowZAzffHOZWKbESEclIhx8OZ50VGlvs2BFtLOvXh5LACy9USaDkpXXADqBJse1NgNIWTbgJmOPud7n7QnefDAwBLjOzFrF9VlfwmCmTbf+sLyXEXGLSBKENIyGb7efuq0rax92HuXtHd+9YvXoUlZGStZYtC0nUgAFw5JGwYAHccQfUrh11ZCIiUoaCAvjoI3jhhWjjeO452LpVCwdLfnL3rcA8oGuxh7oS+jCUpA4hIYtXdL8ol3m9gsdMmXQnV5XJVuMNAp5y9y9LetDMLiQkXv3d/fmqBCqym61b4Q9/gHbtYP78UAI4fXpYHFhERDLeeedBkybRN7YoLISDDoIT0t4gWiRj3ANcYWZXmlkrM7sPaA4MBTCzUWY2Km7/54HzzOxqMzs01n/hfmC+u38Y2+c+4Awz+42ZHWVmNwGnA/em7beKSWtyVclsFQAzOx44hlJKAs3sIkJidYW7j696tCIxM2bAscfCb38bPp2XLg2XQFXPISKSNWrUgIEDw8K9H30UTQxffx1awqtLoOQzdx9LaJF+C7AAOBk4J67i7ODYrWj/kYSGeD8F3gbGA8uA8+L2mUnoIHgFsJAwF6uPu89O7W+zJ3P39L5gaMU+mlAr+RpwFfAToI27ryrKVN29f7HnPQJ0cfc9elvHOoiMBm4gLCBWZGtpo1xF6tat6xs2bChrF8lXX30Fv/51KNL/3vfgH/+Ac86JOioREamkFSvgsMPC8oO//336X3/UKLj8cpg1SyNXkpvMbKO71406jiilPbmCsIgw8CtCt4+3gZ+7+6uxx6YBuPtpcfvXIywudru7/6WE400jrHVV3CvxxymJkivZgzuMHQvXXx86Al5/ffgUrpvXfytERHLCj34UehCtWhVWzUinH/8YFi0Kixqbpfe1RdJByVVEyVUmUXIlu1mxAoYMCa2cOnYM61a1bx91VCIikiTPPBMWFn7mmVDpnS5ffRXmfP3sZ3B38QVpRHKEkqvs6xYokhrbtsFdd4UGFTNmwH33hboNJVYiIjnlxz+G5s3T39ji2WfDR426BIrkNiVXInPmwHHHwa9+BWefDUuWhEuL1apFHZmIiCRZ9erwk5+EAoWVK9P3uuPGhem7xx2XvtcUkfRTciX565tv4Npr4cQT4fPPYcKEUCdy0EFRRyYiIil05ZVhztMjj6Tn9b76KnQJvOgizbUSyXVKriQ/Pf00tG4NDz4I11wT2qtfcEHUUYmISBocfHBobDF8eCjVS7VnnoHt20MLdhHJbUquJL989BGcfz707AmNGsHrr8MDD8C++0YdmYiIpFFBAaxeDc89l/rXKiyEli1DnyQRyW1KriQ/7NgB998fRqumTIE//xnmztVCIyIieepHP4IWLVLf2OLLL+Gll1QSKJIvlFxJ7luwAE46Ca67Djp3hsWLQ/OKGjWijkxERCJSvXqYe/Xii/D++6l7naKSQHUJFMkPSq4kd23YADfeGOowVq2CMWPghRfgkEOijkxERDLAlVeGxrAPP5y61ygshEMPhR/8IHWvISKZQ8mV5KZJk8KaVXffDQMHhoYVF1+smgwREfmfAw8M6149+ihs3Zr843/xRSgJ7N1bHz8i+ULJleSW1auhTx/o3h3q1IFXX4Vhw6Bhw6gjExGRDFRQAGvXhvK9ZHv66TDlVyWBIvnD3D3qGCJVt25d37BhQ9RhSFV98QWMHg233QabNsEtt4R5VbVqRR2ZiIhksB074LDDwm3q1OQe+4c/DPO5li/XyJXkBzPb6O51o44jShq5kuy1cSM8+ST06AFNm8LPfx6K2hctgltvVWIlIiLlqlYNBg2C//43JEHJsm5dSNbUJVAkvyi5kuyyfTv85z9w2WVwwAFhHtWbb8L114efU6fCEUdEHaWIiGSRgQND98Bhw5J3zKKSQC0cLJJfVBaossDM5w5z5sDjj8PYsaE4fr/94MIL4ZJLoEsX2EvXCUREpPJ69YJXXoFPPklO4UPXrrByJSxbppEryR8qC9TIlWSyd9+F3/4Wvv99OPHEcEmxS5dwOXD16tA797TTlFiJiEiVFRSE6btPPVX1Y33+eSgzVEmgSP7RyJVGrjLLp5+G0anHH4d588Kn0hlnhBGqnj2hfv2oIxQRkRy0c2e4lteiRRjBqophw0KytmABHHNMcuITyQYauYLqUQcgwvr1MGFCSKhefjl8wnXoAPfcE9qqN28edYQiIpLj9torNLa46aawNGKrVpU/VmFhmP7brl3y4hOR7KB6KonGli2hvK93b2jSJMwmXrkSbr45fKrNnRu6/ymxEhGRNBkwoOqNLdauDdcJtXCwSH7SyJWkz86dYVHfxx+H8ePh669Dx7/Bg0PZ3/HH65NIREQi06RJqEB/7DG4806oXbvix5gwIXzcaeFgkfykOVeac5Va7vDWWyGheuKJ0Iapbl244IKQUJ11VrhMKCIikgH++18480wYNSqs+lFRZ5wRpg8vXarrhZJ/NOdKyZWSq1RZuRLGjAlJ1ZIlIYHq1i0kVOeeC3XqRB2hiIjIHtzhyCNDYcWMGRV77po1oZr95pvh9ttTE59IJlNypbJASaZ168Is3scfh5kzw7aTT4Z//jOsSdW4cbTxiYiIlMMsVKvfeCMsXgxt2iT+XJUEiohGrjRyVTUbNsCzz4ZRqsmTYfv28El0ySVw8cXQsmXUEYqIiFTIunVw4IGhnfr99yf+vNNPD8swLlmikkDJTxq5UnKl5Koytm+HF18MI1TPPBMSrBYtoF+/kFQdfbQ+VUREJKv16weTJoX5U4lUsq9eHUoCb70Vfv/71McnkomUXKksUBLlDrNmhRGqsWPD8vP77bcroTrllLBIiIiISA4oKAh9mAoL4Yoryt//qafCR6VKAkXym0auNHJVtnfeCSNUY8bABx/A3ntDjx4hoerWDWrVijpCERGRpHOH1q2hfv1wbbE8p50WrjsuXpzy0EQylkautIiwlOSTT+Cvf4UOHcIS9XfeCYcdBo8+GlohFRbCeecpsRIRkZxV1Nhi9uywokhZPvssLOOoUSsRUXIlwfr1MGJEWNzjoIPghhtCmd/f/gYffwxTpoS6iH33jTpSERGRtLj88nAd8aGHyt6vqCSwd+/0xCUimUtlgflcFrh5c5itO2YMTJwIW7bA4YeHkr9+/eCII6KOUEREJFL9+4feTZ9+CvvsU/I+XbrAl1/C22+nNzaRTKOyQI1c5Z8dO+Dll+HKK6FpU+jVC6ZPDzN3Z8+GZcvgttuUWImIiBA+Hr/9Fp58suTHP/00LDaskkARAY1c5cfIlTssWBAaUzz5ZJhTtc8+0LNnGKU64wyorsaRIiIixbmHFUZq14Y33tjz8QcegJ/9LKxt1apV+uMTySQauVJyldvJ1QcfhJK/MWNg6dKQQP3oRyGh6tEjsYU7RERE8lxRAjVvHvzgB7s/dsop8PXXsGhRNLGJZBIlVxGVBZrZEDNbYWabzWyemZ1Sxr4jzcxLuG2I26eZmY0xs3fMbIeZjUzLL5KJPv8cHnwQOnUKHf5uvRUaN4ahQ8MKh889B336KLESERFJ0GWXhZGr4o0tPvlEJYEisru0J1dm1ge4D7gTaA/MBF4ws4NLecp1QLNitw+Awrh9agHrgP8DZqcm8gy2YUMo+eveHZo1g5/+NBSI/+lPsHJl6A9bUACNGkUdqYiISNbZb79wXXLMmPDxWmT8+PBTXQJFpEjaywLNbDaw0N0HxW1bDox395sSeH5nYAbQ2d1nlvD4RGCdu1+RSDxZWxa4bRu8+GJIqp55BjZuDC3U+/ULZX9HHx11hCIiIjlj1iw46aRQCFJQELZ17gzffVf+Olgi+UJlgZDWLgZmVhPoANxd7KEpQKcEDzMIWFxSYlWBOAYDgwFq1qxZ2cOknzu8/npIqAoLYd06aNAg1Cv06wcnnxzWphIREZGkOuEEaNcuJFeDB4eSwJkz4Y47oo5MRDJJulvENQaqAWuKbV8DnFXek82sPnARUO4IV1ncfRgwDMLIVVWOlRZLl4aEaswYWLEC9t4bzj03jFB16wbZlCCKiIhkIbMwYnXNNaFr4MzYJV6VBIpIvGzrv30pYZ7Y6KgDSblPPoEnnghJ1YIFYUTqrLPCGlQXXAD16kUdoYiISF655BK48cbQ2GLpUjjmGC0LKSK7S3dytQ7YATQptr0JsDqB5w8CnnL3L5MdWEb4+mt46qmQUE2bFsoAjzsO7r03zKRt2jTqCEVERPJW/fpw8cXhY3rzZvjjH6OOSEQyTVon6Lj7VmAe0LXYQ10JXQNLZWbHA8cAD6cmuohs3hwSqp49oUkTuPJK+Phj+N3vYNkymDMHrrtOiZWIiEgGuOqq8NENKgkUkT1FURZ4DzDazOYArwFXAc2BoQBmNgrA3fsXe95gYLm7TyvpoGZ2bOw/9wV2xu5vdfclSf8NkunJJ2HAgJA8DRkSGlN07BiKu0VERCSjdOwIxx8fiku+//2ooxGRTJP25Mrdx5pZI+AWwppVbwPnuPuq2C57rHdlZvWAvsDtZRz6zWL3ewCrgJZVjTmlevaEAw+E00+H6tk2BU5ERCT/TJoUkisRkeLSvs5Vpsnada5ERERERDKI1rlK85wrERERERGRXKXkSkREREREJAmUXImIiIiIiCSBkisREREREZEkUHIlIiIiIiIcdy+iAAANHElEQVSSBEquREREREREkkDJlYiIiIiISBIouRIREREREUkCJVciIiIiIiJJoORKREREREQkCZRciYiIiIhI2pjZEDNbYWabzWyemZ1Sxr4jzcxLuG0ott81ZrbUzDaZ2btm1j/1v8melFyJiIiIiEhamFkf4D7gTqA9MBN4wcwOLuUp1wHNit0+AArjjnk18GfgdqAN8DvgQTPrkaJfo1Tm7ul+zYxSt25d37BhQ/k7ioiIiIhIqcxso7vXLWef2cBCdx8Ut205MN7db0rgNToDM4DO7j4ztm0mMNvdfx6331+BE9z95Mr9NpVTPZ0vlokaNmzItGnTog5DRERERCTbVTezuXH3h7n7sKI7ZlYT6ADcXex5U4BOCb7GIGBxUWIVUwvYXGy/TcDxZlbD3bcleOwqy/vk6ssvv+S0006LOgwRERERkWy33d07lvF4Y6AasKbY9jXAWeUd3MzqAxcBxUe4JgM/MbMJwFxCAnclUCP2mp8lFH0S5H1ytXHjRjezTRGHUR3YHnEMuULnMjl0HpNH5zI5dB6TR+cyOXQek0PnMXky4VzWTvHxLyX0jBhdbPsfgKaE+VtGSNYeA34F7ExxTLvJ++TK3SNv6mFmc8vJ8iVBOpfJofOYPDqXyaHzmDw6l8mh85gcOo/JkyXnch2wA2hSbHsTYHUCzx8EPOXuX8ZvdPdNwEAzK4gd6zNgMPAt8HlVg66IyBMLERERERHJfe6+FZgHdC32UFfCqFOpzOx44Bjg4TKOv83dP3b3HUBfYKK7a+RKRERERERy0j3AaDObA7wGXAU0B4YCmNkoAHcvvk7VYGC5u08rfkAzOwI4AZgFNAB+AbQFLk/Nr1A6JVeZYVj5u0iCdC6TQ+cxeXQuk0PnMXl0LpND5zE5dB6TJyvOpbuPNbNGwC2ENaveBs5x91WxXfZY78rM6hFGom4v5bDVCAnVkcA24GWgk7uvTG705cv7da5ERERERESSQXOuREREREREkkDJlYiIiIiISBIouRIREREREUkCJVdpYGZDzGyFmW02s3lmdkoZ+zYzszFm9o6Z7TCzkWkMNeNV8Fz2NLMpZva5mX1rZrPN7Nx0xpupKngeTzWzmWb2hZltir03b0hnvJmsIuey2PNONrPtZvZ2qmPMBhV8T55mZl7C7ah0xpyJKvp+NLOaZnZ77DlbzOxDM/tZuuLNZBV8T44s5T25IZ0xZ6JKvCf7mdkCM9toZqvN7F9m1jRd8WaySpzLa8xsaeyz+10zK959T1JAyVWKmVkf4D7gTqA9oYf/C2a2RyeUmFqEBdb+D5idliCzRCXO5anAf4Husf0nAU8n+uU3V1XiPH4H3A90AVoDdwC/N7MhaQg3o1XiXBY9rwEwCpia8iCzQGXPI9CG0Gmq6LY8lXFmukqexyeBboQWx0cCvYGFKQ4141XiXF7H7u/FZsAHQGHqo81cFT2PZtYZGA08Rvj3fT7hc+fxtAScwSpxLq8G/kzortcG+B3woJn1SE/E+UvdAlPMzGYDC919UNy25cB4d7+pnOdOBNa5+xWpjTI7VOVcxu0/B5ju7r9MUZgZL0nncQKwxd0vTlGYWaGy5zJ2/t4CDLjQ3dumPNgMVtHzaGanEdrs7u/u69IWaIarxHk8GxgHHKbzuLuq/p2MJQkzgM7uXubCqLmsEu/JG4Br3f17cdsGAA+4+z7piDlTVeJczgRmu/vP47b9FTjB3U9OR8z5SiNXKWRmNYEOwJRiD00BOqU/ouyVxHNZD/gqWXFlm2ScRzNrH9v3leRGl10qey5jI35NCCOAea+K78m5ZvaZmU01s9NTEmCWqOR5PB94A/iFmX1sZsvN7H4zy/cvscn4vBkELM7zxKoy5/E1oJmZ9bCgMWFto0mpizTzVfJc1gI2F9u2CTjezGokN0KJp+QqtRoTFjVbU2z7GkD1wxVT5XNpZtcALQglB/mq0ucx9uVrCzAX+Ie7D01NiFmjwufSzI4mlGZc6u47Uhte1qjMe/Iz4GqgF9ATeBeYmuclv5U5j4cCJwPHEM7lTwklgiNTE2LWqNLnjZnVBy4CHk5+aFmlwufR3V8nJFOPA1uBzwkj/JenLsysUJn35GRgoJkdF0tUOwJXAjVix5MUqR51ACLpYGa9gLuAPnErgEvFnALsA5wI/NnMVrh7PieqFWJmtYCxwA3uviLqeLKZu79LSKiKvG5mLYEbgelRxJSl9gIc6Ofu6wHM7KfAZDNr4u7Fv8hJYi4lnFv9fawgM2sNPAD8gZAcNCN8dj8EqBlDxfyBkHjNJCSoawhz2X4F7IwwrpynkavUWgfsIJQAxWsCrE5/OFmt0ufSzC4kfMj1d/fnUxNe1qj0eXT3Fe6+yN0fBu4BbktJhNmjoueyGdAKeNRCl8DtwG+BNrH7Z6c02syVrL+Ts4HvJyuoLFSZ8/gZ8ElRYhWzNPazvGYiuayq78lBwFPu/mWyA8sylTmPNwFz3P0ud1/o7pOBIcBlZtYidaFmvAqfS3ff5O4DgTpAS8K/6ZXAt4QRQUkRJVcp5O5bgXlA12IPdSVcSZAEVfZcmtlFhMTqCncfn7oIs0MS35N7Eeq581YlzuUnwNHAsXG3ocB7sf/Oy78JSXxPHktIFvJSJc/ja0DzYnOsjoj9zNsR/qq8J83seEKZZb6XBFb2PNYhJBHxiu7n7XfWqrwn3X2bu38cK0XvC0x0d41cpZDKAlPvHmB0rEvda8BVQHPClyrMbBSAu/9vuNvMjo39577Aztj9re6+JJ2BZ6AKnUsz60tIrG4AXo1bJ2Nrnl9RrOh5vBZYwa4yrC6Ec/qP9IadkRI+l+6+DdhtTSszW0voupjva11V9D15PeEK7GKgJqEM63zCvKF8VtHPmzHArYTR1NuA/Qitnse7+9r0hp5xKvzZHTMYWO7u09IXakar6Hl8Hng41ka8qCzwXmC+u3+Y5tgzTUX/Th4BnADMAhoAvwDaovlrKafkKsXcfayZNQJuIfyReBs4J27eT0mlF28Wu9+DcBWxZarizAaVOJdXEd7j98ZuRV4BTktttJmrEuexGmGtjJbAduB94DfE/qDns0r++5ZiKnEeaxLmYbQgdL9aDHR397zuKFbR8+ju35nZWYQ5Lm8QOqk+Q/j3ndcq82/bzOoRRgZuT1ugGa4S78mRsfP4U+CvwHrCepW/Tl/UmamSn92/IKxft42wfEUnd1+Znojzl9a5EhERERERSYK8rV8VERERERFJJiVXIiIiIiIiSaDkSkREREREJAmUXImIiIiIiCSBkisREREREZEkUHIlIiIiIiKSBEquRETymJndZmYeu90WdTwlicV4m5ldkcC+LeN+n/JuI1MfvYiI5BMtIiwiIpnud7GfrwAjI4xDRESkTBq5EhGRnOHuK93dim7A6XEPvxL/mLtfEVGYIiKSo5RciYj8/3buHcSuKorD+PcXEyIMPiCIpnCigiCC1k6j+EIQQQRTJIUTiIVFrES0EbHQwkpr0VGihSg2aiEIESH4aESUEIMRtRCDcZBhlInKsjhnyGa8d46PMxnGfD+4nL33XfecdavLYq+79RdJFpr2ubkkh5IsJjmV5I0klzWxbSveQpL9SY4mWUlybG07X5LDq/HrrSeZXxNzU/OcwyN+16eSfJTkhySnkywn+TTJI0m2NXF3Ns9/dGhdknTusS1QkjTkbeDiZn4vcBFw24TYu4D7m/k1wItJzquqFzYuxf9kLzDbzLcBN/SvK4EHNyMpSdLW486VJGnI18DVdIXSyX7t1iSXT4jdSVdcXQjsa9afbneB/o6qWuhb+1a1bX03/5N7DXgYuJauYNxO9z2/6N87kGRmxGdJkv7HLK4kSUMer6oTVXUc+KBZn50Qe6SqXq6qpap6FTjSr18KXL/Rif5Ly8BzwFfAr8CXwHX9e+fTFZaSJA2yLVCSNORYM15uxjsmxH47YT7Xj3cOPOes/yYluYWu7THrhF0wcBt/SyVJgDtXkqRhvzXjmhrVuWKd+Y/9dWV1IcmO/hq6/zedbXs4U1g9Ccz0rYjvTIhdacZtYXnVBuUmSdpiLK4kSWOaS7IvyUySvZzZtToJfNaPv2ni7+6vB4FdU+55qr/OJrlk1Gzh92a8BPyR5B7g9gmxbd53JNmeZBfw0Mg5SZK2KIsrSdKYvgcO0RUqrzTrj1XV6g5Yu/5akiXgWbr/O03yYX/dDfzUH3n+xEj5vtmMn+lzeB34bm1gVZ1ocrkRWOzjJh3sIUk6B1lcSZLG9C7dKYFHgdPAcWB/ewx7Vb0PHKA7OGKF7iCJ+4CPp9zzIF2b3uLYyVbVe8B8k8vndEfNfzLlI3uAt4CfgV+A54EHxs5LkrQ1pWqofV6SpOmS7KY7rh3gpaqa37RkJEnaRO5cSZIkSdIILK4kSZIkaQS2BUqSJEnSCNy5kiRJkqQRWFxJkiRJ0ggsriRJkiRpBBZXkiRJkjQCiytJkiRJGsGf2MMkadTQBb0AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 936x504 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display(Markdown(\"### Plot of accuracy and output fairness vs input constraint (tau)\"))\n",
+    "\n",
+    "display(Markdown(\"#### Output fairness is represented by $\\gamma_{fdr}$, which is the ratio of false discovery rate of different sensitive attribute values.\"))\n",
+    "\n",
+    "fig, ax1 = plt.subplots(figsize=(13,7))\n",
+    "ax1.plot(all_tau, accuracies, color='r')\n",
+    "ax1.set_title('Accuracy and $\\gamma_{fdr}$ vs Tau', fontsize=16, fontweight='bold')\n",
+    "ax1.set_xlabel('Input Tau', fontsize=16, fontweight='bold')\n",
+    "ax1.set_ylabel('Accuracy', color='r', fontsize=16, fontweight='bold')\n",
+    "ax1.xaxis.set_tick_params(labelsize=14)\n",
+    "ax1.yaxis.set_tick_params(labelsize=14)\n",
+    "\n",
+    "ax2 = ax1.twinx()\n",
+    "ax2.plot(all_tau, false_discovery_rates, color='b')\n",
+    "ax2.set_ylabel('$\\gamma_{fdr}$', color='b', fontsize=16, fontweight='bold')\n",
+    "ax2.yaxis.set_tick_params(labelsize=14)\n",
+    "ax2.grid(True)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -483,13 +727,6 @@
     "#         Celis, L. E., Huang, L., Keswani, V., & Vishnoi, N. K. (2018). \n",
     "#         \"Classification with Fairness Constraints: A Meta-Algorithm with Provable Guarantees.\"\"\n"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/demo_meta_classifier.ipynb
+++ b/examples/demo_meta_classifier.ipynb
@@ -31,7 +31,7 @@
     "\n",
     "from aif360.algorithms.preprocessing.optim_preproc_helpers.data_preproc_functions import load_preproc_data_adult, load_preproc_data_compas, load_preproc_data_german\n",
     "\n",
-    "from aif360.algorithms.inprocessing.meta_fair_classifier import MetaFairClassifer\n",
+    "from aif360.algorithms.inprocessing.meta_fair_classifier import MetaFairClassifier\n",
     "from aif360.algorithms.inprocessing.celisMeta.utils import getStats\n",
     "from IPython.display import Markdown, display\n",
     "import matplotlib.pyplot as plt\n",
@@ -439,7 +439,7 @@
    ],
    "source": [
     "# Get classifier without fairness constraints\n",
-    "biased_model = MetaFairClassifer(tau=0, sensitive_attr=\"sex\")\n",
+    "biased_model = MetaFairClassifier(tau=0, sensitive_attr=\"sex\")\n",
     "biased_model.fit(dataset_orig_train)"
    ]
   },
@@ -505,7 +505,7 @@
    "source": [
     "# Learn debiased classifier\n",
     "tau = 0.8\n",
-    "debiased_model = MetaFairClassifer(tau=tau, sensitive_attr=\"sex\")\n",
+    "debiased_model = MetaFairClassifier(tau=tau, sensitive_attr=\"sex\")\n",
     "debiased_model.fit(dataset_orig_train)\n"
    ]
   },
@@ -651,7 +651,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "biased_model = MetaFairClassifer(tau=0, sensitive_attr=\"race\")\n",
+    "biased_model = MetaFairClassifier(tau=0, sensitive_attr=\"race\")\n",
     "biased_model.fit(dataset_orig_train)\n",
     "\n",
     "dataset_bias_test = biased_model.predict(dataset_orig_test)\n",
@@ -816,7 +816,7 @@
     "all_tau = np.linspace(0.1, 0.9, 9)\n",
     "for tau in all_tau:\n",
     "    print(\"Tau: %.2f\" % tau)\n",
-    "    debiased_model = MetaFairClassifer(tau=tau, sensitive_attr=s_attr)\n",
+    "    debiased_model = MetaFairClassifier(tau=tau, sensitive_attr=s_attr)\n",
     "    debiased_model.fit(dataset_orig_train)\n",
     "    \n",
     "    dataset_debiasing_test = debiased_model.predict(dataset_orig_test)\n",
@@ -925,7 +925,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.14"
+   "version": "2.7.15"
   }
  },
  "nbformat": 4,

--- a/tests/test_meta_classifier.py
+++ b/tests/test_meta_classifier.py
@@ -1,0 +1,17 @@
+# Adapted from:
+# http://www.christianmoscardi.com/blog/2016/01/20/jupyter-testing.html
+
+from notebook_runner import notebook_run
+import os
+
+
+def test_meta_classifier():
+    nb, errors = notebook_run(os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            '..', 'examples', 'demo_meta_classifier.ipynb'))
+
+    if len(errors) > 0:
+        for err in errors:
+            for tbi in err['traceback']:
+                print(tbi)
+        raise AssertionError("errors in notebook testcases")

--- a/tests/test_meta_classifier.py
+++ b/tests/test_meta_classifier.py
@@ -32,7 +32,7 @@ def test_adult():
 	#scaler = MinMaxScaler(copy=False)
 	# ad.features = scaler.fit_transform(ad.features)
 
-	train, test = ad.split([32561])
+	train, test = ad.split([32562])
 	assert np.any(test.labels)
 
 	#print(test.labels)

--- a/tests/test_meta_classifier.py
+++ b/tests/test_meta_classifier.py
@@ -1,17 +1,69 @@
-# Adapted from:
-# http://www.christianmoscardi.com/blog/2016/01/20/jupyter-testing.html
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
-from notebook_runner import notebook_run
-import os
+import sys
+sys.path.append("../")
+from aif360.datasets import BinaryLabelDataset
+from aif360.datasets import AdultDataset, GermanDataset, CompasDataset
+from aif360.metrics import BinaryLabelDatasetMetric
+from aif360.metrics import ClassificationMetric
+from aif360.metrics.utils import compute_boolean_conditioning_vector
+from sklearn.linear_model import LogisticRegression
+from sklearn.preprocessing import StandardScaler, MaxAbsScaler
+from sklearn.metrics import accuracy_score
+
+from aif360.algorithms.preprocessing.optim_preproc_helpers.data_preproc_functions import load_preproc_data_adult, load_preproc_data_compas, load_preproc_data_german
+
+from aif360.algorithms.inprocessing.meta_fair_classifier import MetaFairClassifier
+from aif360.algorithms.inprocessing.celisMeta.utils import getStats
+from IPython.display import Markdown, display
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+def test_adult():
+	protected = 'sex'
+	ad = AdultDataset(protected_attribute_names=[protected],
+	    privileged_classes=[['Male']], categorical_features=[],
+	    features_to_keep=['age', 'education-num', 'capital-gain', 'capital-loss', 'hours-per-week'])
+
+	#scaler = MinMaxScaler(copy=False)
+	# ad.features = scaler.fit_transform(ad.features)
+
+	train, test = ad.split([32561])
+	assert np.any(test.labels)
+
+	#print(test.labels)
+
+	biased_model = MetaFairClassifier(tau=0, sensitive_attr=protected)
+	biased_model.fit(train)
+
+	dataset_bias_test = biased_model.predict(test)
+
+	predictions = [1 if y == train.favorable_label else -1 for y in list(dataset_bias_test.labels)]
+	y_test = np.array([1 if y == [train.favorable_label] else -1 for y in test.labels])
+	x_control_test = pd.DataFrame(data=test.features, columns=test.feature_names)[protected]
+
+	acc, sr, unconstrainedFDR = getStats(y_test, predictions, x_control_test)
+	#print(unconstrainedFDR)
 
 
-def test_meta_classifier():
-    nb, errors = notebook_run(os.path.join(
-            os.path.dirname(os.path.abspath(__file__)),
-            '..', 'examples', 'demo_meta_classifier.ipynb'))
+	tau = 0.9
+	debiased_model = MetaFairClassifier(tau=tau, sensitive_attr=protected)
+	debiased_model.fit(train)
 
-    if len(errors) > 0:
-        for err in errors:
-            for tbi in err['traceback']:
-                print(tbi)
-        raise AssertionError("errors in notebook testcases")
+	#dataset_debiasing_train = debiased_model.predict(dataset_orig_train)
+	dataset_debiasing_test = debiased_model.predict(test)
+
+	predictions = list(dataset_debiasing_test.labels)
+	predictions = [1 if y == train.favorable_label else -1 for y in predictions]
+	y_test = np.array([1 if y == [train.favorable_label] else -1 for y in test.labels])
+	x_control_test = pd.DataFrame(data=test.features, columns=test.feature_names)[protected]
+
+	acc, sr, fdr = getStats(y_test, predictions, x_control_test)
+	#print(fdr, unconstrainedFDR)
+	assert(fdr >= unconstrainedFDR)
+
+#test_adult()


### PR DESCRIPTION
As per discussion with Sameep Mehta, I have added support for the Fair Classification meta-algorithm that we developed. The implementation is based on the following work: 
_Classification with Fairness Constraints: A Meta-Algorithm with Provable Guarantees_ - https://arxiv.org/abs/1806.06055.

The algorithm we suggest in the paper takes the fairness metric as input and corresponding to the metric specified, the optimization problem is different. In this implementation, we provide code for optimizing two fairness metrics: Statistical Rate and False Discovery Rate. 

The main implementation file is **meta_fair_classifier.py**. The algorithm is implemented in the folder **celisMeta**. I have added a Jupyter test notebook for this algorithm as well - **demo_meta_classifier.ipynb**. 

I have tried to loosely follow the coding style used for other implemented algorithms. Any comments on the code/algorithm will be very helpful and please let me know any changes I should make before this can be merged.