### PR TITLE
Travis CI: Add flake8 tests to find syntax errors and undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: python
 
 env: MLDB_URL="ftp://ftp.ics.uci.edu/pub/machine-learning-databases"
 
+branches:
+  only:
+    - master
+
 install:
   - pip install -r requirements.txt
   - pip install flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,43 +1,29 @@
-dist: trusty
-sudo: false
-
 language: python
-python:
-  - "2.7"
-  - "3.6"
 
-install: pip install -r requirements.txt
+install:
+  - pip install -r requirements.txt
+  - pip install flake8
+  - wget ftp://ftp.ics.uci.edu/pub/machine-learning-databases/adult/adult.data -P aif360/data/raw/adult/
+  - wget ftp://ftp.ics.uci.edu/pub/machine-learning-databases/adult/adult.test -P aif360/data/raw/adult/
+  - wget ftp://ftp.ics.uci.edu/pub/machine-learning-databases/adult/adult.names -P aif360/data/raw/adult/
+  - wget ftp://ftp.ics.uci.edu/pub/machine-learning-databases/statlog/german/german.data -P aif360/data/raw/german/
+  - wget ftp://ftp.ics.uci.edu/pub/machine-learning-databases/statlog/german/german.doc -P aif360/data/raw/german/
+  - wget https://raw.githubusercontent.com/propublica/compas-analysis/master/compas-scores-two-years.csv -P aif360/data/raw/compas/
 
 matrix:
-  # different requirements for different python versions
+  # Python 2.7 has a special requirement for BlackBoxAuditing
   include:
   - python: "2.7"
     before_script:
-    - wget ftp://ftp.ics.uci.edu/pub/machine-learning-databases/adult/adult.data -P aif360/data/raw/adult/
-    - wget ftp://ftp.ics.uci.edu/pub/machine-learning-databases/adult/adult.test -P aif360/data/raw/adult/
-    - wget ftp://ftp.ics.uci.edu/pub/machine-learning-databases/adult/adult.names -P aif360/data/raw/adult/
-    - wget ftp://ftp.ics.uci.edu/pub/machine-learning-databases/statlog/german/german.data -P aif360/data/raw/german/
-    - wget ftp://ftp.ics.uci.edu/pub/machine-learning-databases/statlog/german/german.doc -P aif360/data/raw/german/
-    - wget https://raw.githubusercontent.com/propublica/compas-analysis/master/compas-scores-two-years.csv -P aif360/data/raw/compas/
     - git clone https://github.com/algofairness/BlackBoxAuditing.git /tmp/BlackBoxAuditing/
     - echo -n /tmp/BlackBoxAuditing/BlackBoxAuditing/weka.jar > /tmp/BlackBoxAuditing/python2_source/BlackBoxAuditing/model_factories/weka.path
     - echo include python2_source/BlackBoxAuditing/model_factories/weka.path >> /tmp/BlackBoxAuditing/MANIFEST.in
     - pip install --no-deps /tmp/BlackBoxAuditing/
-  # workaround to exclude extraneous builds
-  - python: "3.6"
-    before_script:
-    - wget ftp://ftp.ics.uci.edu/pub/machine-learning-databases/adult/adult.data -P aif360/data/raw/adult/
-    - wget ftp://ftp.ics.uci.edu/pub/machine-learning-databases/adult/adult.test -P aif360/data/raw/adult/
-    - wget ftp://ftp.ics.uci.edu/pub/machine-learning-databases/adult/adult.names -P aif360/data/raw/adult/
-    - wget ftp://ftp.ics.uci.edu/pub/machine-learning-databases/statlog/german/german.data -P aif360/data/raw/german/
-    - wget ftp://ftp.ics.uci.edu/pub/machine-learning-databases/statlog/german/german.doc -P aif360/data/raw/german/
-    - wget https://raw.githubusercontent.com/propublica/compas-analysis/master/compas-scores-two-years.csv -P aif360/data/raw/compas/
-  exclude:
-  - python: "2.7"
   - python: "3.6"
 
-branches:
-  only:
-  - master
-
-script: travis_wait pytest tests
+script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - travis_wait pytest tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,12 @@ matrix:
     - echo include python2_source/BlackBoxAuditing/model_factories/weka.path >> /tmp/BlackBoxAuditing/MANIFEST.in
     - pip install --no-deps /tmp/BlackBoxAuditing/
   - python: "3.6"
+    before_script:
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+    - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
 
 script:
   # stop the build if there are Python syntax errors or undefined names
   - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
-  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
   - travis_wait pytest tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 language: python
 
+env: MLDB_URL="ftp://ftp.ics.uci.edu/pub/machine-learning-databases"
+
 install:
   - pip install -r requirements.txt
   - pip install flake8
-  - wget ftp://ftp.ics.uci.edu/pub/machine-learning-databases/adult/adult.data -P aif360/data/raw/adult/
-  - wget ftp://ftp.ics.uci.edu/pub/machine-learning-databases/adult/adult.test -P aif360/data/raw/adult/
-  - wget ftp://ftp.ics.uci.edu/pub/machine-learning-databases/adult/adult.names -P aif360/data/raw/adult/
-  - wget ftp://ftp.ics.uci.edu/pub/machine-learning-databases/statlog/german/german.data -P aif360/data/raw/german/
-  - wget ftp://ftp.ics.uci.edu/pub/machine-learning-databases/statlog/german/german.doc -P aif360/data/raw/german/
+  - wget ${MLDB_URL}/adult/adult.data -P aif360/data/raw/adult/
+  - wget ${MLDB_URL}/adult/adult.test -P aif360/data/raw/adult/
+  - wget ${MLDB_URL}/adult/adult.names -P aif360/data/raw/adult/
+  - wget ${MLDB_URL}/statlog/german/german.data -P aif360/data/raw/german/
+  - wget ${MLDB_URL}/statlog/german/german.doc -P aif360/data/raw/german/
   - wget https://raw.githubusercontent.com/propublica/compas-analysis/master/compas-scores-two-years.csv -P aif360/data/raw/compas/
 
 matrix:
@@ -23,7 +25,6 @@ matrix:
     before_script:
     # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
     - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-
 
 script:
   # stop the build if there are Python syntax errors or undefined names

--- a/aif360/algorithms/inprocessing/kamfadm-2012ecmlpkdd/fadm/lr/pr.py
+++ b/aif360/algorithms/inprocessing/kamfadm-2012ecmlpkdd/fadm/lr/pr.py
@@ -241,7 +241,7 @@ class LRwPRFittingType1Mixin(LRwPR):
                 clr.fit(X[s == i, :], y[s == i])
                 coef[i, :] = clr.coef_
         else:
-            raise typeError
+            raise TypeError
 
     def fit(self, X, y, ns=N_S, itype=0, **kwargs):
         """ train this model


### PR DESCRIPTION
Another attempt at #15 which also tries to consolidate repetitive parts of the __.travis.yml__ file.

Add [flake8](http://flake8.pycqa.org) tests to find Python syntax errors and undefined names.

__E901,E999,F821,F822,F823__ are the "_showstopper_" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree