### PR TITLE
README.md breaking very line lines to ~80 cols

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,29 @@
 
 [![Build Status](https://travis-ci.com/IBM/AIF360.svg?branch=master)](https://travis-ci.com/IBM/AIF360)
 
-The AI Fairness 360 toolkit is an open-source library to help detect and remove bias in machine learning models. The AI Fairness 360 Python package includes a comprehensive set of metrics for datasets and models to test for biases, explanations for these metrics, and algorithms to mitigate bias in datasets and models.
+The AI Fairness 360 toolkit is an open-source library to help detect and remove
+bias in machine learning models. The AI Fairness 360 Python package includes a
+comprehensive set of metrics for datasets and models to test for biases,
+explanations for these metrics, and algorithms to mitigate bias in datasets and
+models.
 
-The [AI Fairness 360 interactive experience](http://aif360.mybluemix.net/data) provides a gentle introduction to the concepts and capabilities. The [tutorials and other notebooks](./examples) offer a deeper, data scientist-oriented introduction. The complete API is also available.
+The [AI Fairness 360 interactive experience](http://aif360.mybluemix.net/data)
+provides a gentle introduction to the concepts and capabilities. The [tutorials
+and other notebooks](./examples) offer a deeper, data scientist-oriented
+introduction. The complete API is also available.
 
-Being a comprehensive set of capabilities, it may be confusing to figure out which metrics and algorithms are most appropriate for a given use case. To help, we have created some [guidance material](http://aif360.mybluemix.net/resources#guidance) that can be consulted.
+Being a comprehensive set of capabilities, it may be confusing to figure out
+which metrics and algorithms are most appropriate for a given use case. To
+help, we have created some [guidance
+material](http://aif360.mybluemix.net/resources#guidance) that can be
+consulted.
 
-We have developed the package with extensibility in mind. This library is still in development. We encourage the contribution of your metrics, explainers, and debiasing algorithms.
+We have developed the package with extensibility in mind. This library is still
+in development. We encourage the contribution of your metrics, explainers, and
+debiasing algorithms.
 
-Get in touch with us on [Slack](https://aif360.slack.com) (invitation [here](https://join.slack.com/t/aif360/shared_invite/enQtNDI5Nzg2NTk0MTMyLTU4N2UwODVmMTYxZWMwZmEzZmZkODdjMTk5NWUwZDNhNDhlMzNkZDNhOTYwZDNlODc1MTdjYzY5OTU2OWQ1ZmY))!
+Get in touch with us on [Slack](https://aif360.slack.com) (invitation
+[here](https://join.slack.com/t/aif360/shared_invite/enQtNDI5Nzg2NTk0MTMyLTU4N2UwODVmMTYxZWMwZmEzZmZkODdjMTk5NWUwZDNhNDhlMzNkZDNhOTYwZDNlODc1MTdjYzY5OTU2OWQ1ZmY))!
 
 
 ## Supported bias mitigation algorithms
@@ -43,15 +57,25 @@ Supported Configurations:
 | Ubuntu  | 2.7, 3.5, 3.6  |
 | Windows | 3.5            |
 
-Installation is easiest on a Unix-like system running Python 3. See the [Troubleshooting](#troubleshooting) section if you have issues with other configurations.
+Installation is easiest on a Unix-like system running Python 3. See the
+[Troubleshooting](#troubleshooting) section if you have issues with other
+configurations.
 
 ### (Optional) Create a virtual environment
 
-AIF360 requires specific versions of many Python packages which may conflict with other projects on your system. A virtual environment manager is strongly recommended to ensure dependencies may be installed safely. If you have trouble installing AIF360, try this first.
+AIF360 requires specific versions of many Python packages which may conflict
+with other projects on your system. A virtual environment manager is strongly
+recommended to ensure dependencies may be installed safely. If you have trouble
+installing AIF360, try this first.
 
 #### Conda
 
-Conda is recommended for all configurations though Virtualenv is generally interchangeable for our purposes ([CVXPY](#cvxpy) may require conda in some cases). Miniconda is sufficient (see [the difference between Anaconda and Miniconda](https://conda.io/docs/user-guide/install/download.html#anaconda-or-miniconda) if you are curious) and can be installed from [here](https://conda.io/miniconda.html) if you do not already have it.
+Conda is recommended for all configurations though Virtualenv is generally
+interchangeable for our purposes ([CVXPY](#cvxpy) may require conda in some
+cases). Miniconda is sufficient (see [the difference between Anaconda and
+Miniconda](https://conda.io/docs/user-guide/install/download.html#anaconda-or-miniconda)
+if you are curious) and can be installed from
+[here](https://conda.io/miniconda.html) if you do not already have it.
 
 Then, to create a new Python 3.5 environment, run:
 
@@ -68,7 +92,8 @@ The shell should now look like `(aif360) $`. To deactivate the environment, run:
 
 The prompt will return to `$ `.
 
-Note: Older versions of conda may use `source activate aif360` and `source deactivate` (`activate aif360` and `deactivate` on Windows).
+Note: Older versions of conda may use `source activate aif360` and `source
+deactivate` (`activate aif360` and `deactivate` on Windows).
 
 ### Install with minimal dependencies
 
@@ -78,9 +103,11 @@ To install the latest stable version from PyPI, run:
 pip install aif360
 ```
 
-This package supports Python 2.7, 3.5, and 3.6. However, for Python 2, the `BlackBoxAuditing` package must be [installed manually](#blackboxauditing).
+This package supports Python 2.7, 3.5, and 3.6. However, for Python 2, the
+`BlackBoxAuditing` package must be [installed manually](#blackboxauditing).
 
-Some algorithms require additional dependencies not included in the minimal installation. To use these, we recommend a full installation.
+Some algorithms require additional dependencies not included in the minimal
+installation. To use these, we recommend a full installation.
 
 ### Full installation
 
@@ -90,7 +117,9 @@ Clone the latest version of this repository:
 git clone https://github.com/IBM/AIF360
 ```
 
-If you'd like to run the examples, download the datasets now and place them in their respective folders as described in [aif360/data/README.md](aif360/data/README.md).
+If you'd like to run the examples, download the datasets now and place them in
+their respective folders as described in
+[aif360/data/README.md](aif360/data/README.md).
 
 Then, navigate to the root directory of the project and run:
 
@@ -106,13 +135,20 @@ To run the example notebooks, install the additional requirements as follows:
 pip install -r requirements.txt
 ```
 
-Then, follow the [Getting Started](https://pytorch.org) instructions from PyTorch to download and install the latest version for your machine.
+Then, follow the [Getting Started](https://pytorch.org) instructions from
+PyTorch to download and install the latest version for your machine.
 
-Finally, if you did not already, download the datasets as described in [aif360/data/README.md](aif360/data/README.md) but place them **in the appropriate sub-folder** in `$ANACONDA_PATH/envs/aif360/lib/python3.5/site-packages/aif360/data/raw` where `$ANACONDA_PATH` is the base path to your conda installation (e.g. `~/anaconda`).
+Finally, if you did not already, download the datasets as described in
+[aif360/data/README.md](aif360/data/README.md) but place them **in the
+appropriate sub-folder** in
+`$ANACONDA_PATH/envs/aif360/lib/python3.5/site-packages/aif360/data/raw` where
+`$ANACONDA_PATH` is the base path to your conda installation (e.g.
+`~/anaconda`).
 
 ### Troubleshooting
 
-If you encounter any errors during the installation process, look for your issue here and try the solutions.
+If you encounter any errors during the installation process, look for your
+issue here and try the solutions.
 
 #### TensorFlow
 
@@ -129,13 +165,16 @@ pip install --upgrade https://storage.googleapis.com/tensorflow/mac/cpu/tensorfl
 pip install --upgrade https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.1.0-cp36-cp36m-linux_x86_64.whl
 ```
 
-Substitute Python version numbers for your configuration as appropriate (Note: TensorFlow 1.1.0 only supports Python 3.5 officially on Windows).
+Substitute Python version numbers for your configuration as appropriate (Note:
+TensorFlow 1.1.0 only supports Python 3.5 officially on Windows).
 
-TensorFlow is only required for use with the `aif360.algorithms.inprocessing.AdversarialDebiasing` class.
+TensorFlow is only required for use with the
+`aif360.algorithms.inprocessing.AdversarialDebiasing` class.
 
 #### CVXPY
 
-On Windows, you may need to download the appropriate [Visual Studio C++ compiler for Python](https://wiki.python.org/moin/WindowsCompilers) and run:
+On Windows, you may need to download the appropriate [Visual Studio C++
+compiler for Python](https://wiki.python.org/moin/WindowsCompilers) and run:
 
 ```bat
 conda install -c https://conda.anaconda.org/omnia scs
@@ -147,13 +186,18 @@ Then, rerun:
 pip install cvxpy==0.4.11
 ```
 
-See the [CVXPY 0.4.11 Installation Instructions](https://www.cvxpy.org/versions/0.4.11/install/index.html#windows-with-anaconda) for details.
+See the [CVXPY 0.4.11 Installation
+Instructions](https://www.cvxpy.org/versions/0.4.11/install/index.html#windows-with-anaconda)
+for details.
 
-CVXPY is only required for use with the `aif360.algorithms.preprocessing.OptimPreproc` class.
+CVXPY is only required for use with the
+`aif360.algorithms.preprocessing.OptimPreproc` class.
 
 #### BlackBoxAuditing
 
-Some additional installation is required to use `aif360.algorithms.preprocessing.DisparateImpactRemover` with Python 2.7. In a directory of your choosing, run:
+Some additional installation is required to use
+`aif360.algorithms.preprocessing.DisparateImpactRemover` with Python 2.7. In a
+directory of your choosing, run:
 
 ```bash
 git clone https://github.com/algofairness/BlackBoxAuditing
@@ -171,13 +215,17 @@ This will produce a minimal installation which satisfies our requirements.
 
 ## Using AIF360
 
-The `examples` directory contains a diverse collection of jupyter notebooks that use AI Fairness 360 in various ways.
-Both tutorials and demos illustrate working code using AIF360. Tutorials provide additional discussion that walks the
-user through the various steps of the notebook. See the details about [tutorials and demos here](examples/README.md)
+The `examples` directory contains a diverse collection of jupyter notebooks
+that use AI Fairness 360 in various ways. Both tutorials and demos illustrate
+working code using AIF360. Tutorials provide additional discussion that walks
+the user through the various steps of the notebook. See the details about
+[tutorials and demos here](examples/README.md)
 
 ## Citing AIF360
 
-A technical description of AI Fairness 360 is available in this [paper](https://arxiv.org/abs/1810.01943).  Below is the bibtex entry for this paper.
+A technical description of AI Fairness 360 is available in this
+[paper](https://arxiv.org/abs/1810.01943). Below is the bibtex entry for this
+paper.
 
 ```
 @misc{aif360-oct-2018,
@@ -196,4 +244,5 @@ A technical description of AI Fairness 360 is available in this [paper](https://
 
 ## AIF360 Videos
 
-* Introductory [video](https://www.youtube.com/watch?v=X1NsrcaRQTE) to AI Fairness 360 by Kush Varshney, September 20, 2018 (32 mins)
+* Introductory [video](https://www.youtube.com/watch?v=X1NsrcaRQTE) to AI
+  Fairness 360 by Kush Varshney, September 20, 2018 (32 mins)


### PR DESCRIPTION
Reading the README in a text editor without line wrapping and/or on a wide monitor seems odd with the current long lines.

This PR only wraps the lines to ~80 chars. The rendered output is no different than the current in master.