### PR TITLE
restrict numpy version below 1.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ branches:
     - master
 
 install:
+  - pip install numpy==1.15
   - pip install -r requirements.txt
   - pip install flake8
   - if ! wget ${UCI_HTTPS_URL}/adult/adult.data -P aif360/data/raw/adult/ ; then wget ${UCI_FTP_URL}/adult/adult.data -P aif360/data/raw/adult/ ; fi
@@ -28,6 +29,7 @@ matrix:
     - echo -n /tmp/BlackBoxAuditing/BlackBoxAuditing/weka.jar > /tmp/BlackBoxAuditing/python2_source/BlackBoxAuditing/model_factories/weka.path
     - echo include python2_source/BlackBoxAuditing/model_factories/weka.path >> /tmp/BlackBoxAuditing/MANIFEST.in
     - pip install --no-deps /tmp/BlackBoxAuditing/
+    - pip list
   - python: "3.6"
     before_script:
     # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ ipykernel
 ipython
 ipywidgets
 tqdm
-numpy>=1.14
+numpy>=1.14,<1.16
 matplotlib
 pandas==0.23.3
 pytest

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(name='aif360',
       packages=find_packages(),
       # python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <3.7',
       install_requires=[
-          'numpy',
+          'numpy>=1.14,<1.16',
           'scipy',
           'pandas==0.23.3',
           'scikit-learn',


### PR DESCRIPTION
numpy 1.16 appears to be incompatible with tensorflow 1.1.0 (np.matmul is now a ufunc which caused errors in the Python 2.7 Travis runs)