### PR TITLE
fixed line length for viewing on GitHub, removed warnings

### DIFF
--- a/aif360/datasets/binary_label_dataset.py
+++ b/aif360/datasets/binary_label_dataset.py
@@ -33,6 +33,10 @@ class BinaryLabelDataset(StructuredDataset):
             ValueError: `favorable_label` and `unfavorable_label` must be the
                 only values present in `labels`.
         """
+        # fix scores before validating
+        if np.all(self.scores == self.labels):
+            self.scores = np.float64(self.scores == self.favorable_label)
+
         super(BinaryLabelDataset, self).validate_dataset()
 
         # =========================== SHAPE CHECKING ===========================
@@ -47,6 +51,3 @@ class BinaryLabelDataset(StructuredDataset):
                 set([self.favorable_label, self.unfavorable_label])):
             raise ValueError("The favorable and unfavorable labels provided do "
                              "not match the labels in the dataset.")
-
-        if np.all(self.scores == self.labels):
-            self.scores = (self.scores == self.favorable_label).astype(np.float64)

--- a/examples/demo_optim_preproc_adult.ipynb
+++ b/examples/demo_optim_preproc_adult.ipynb
@@ -172,13 +172,6 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:root:Privileged and unprivileged groups specified will not be used. The protected attributes are directly specified in data preprocessing function. The current implementation automatically adjusts for discrimination across all groups. This can be changed by changing the optimization code.\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -194,9 +187,7 @@
     "    \"dlist\": [.1, 0.05, 0]\n",
     "}\n",
     "    \n",
-    "OP = OptimPreproc(OptTools, optim_options,\n",
-    "                  unprivileged_groups = unprivileged_groups,\n",
-    "                  privileged_groups = privileged_groups)\n",
+    "OP = OptimPreproc(OptTools, optim_options)\n",
     "\n",
     "OP = OP.fit(dataset_orig_train)\n",
     "dataset_transf_train = OP.transform(dataset_orig_train, transform_Y=True)\n",

--- a/examples/tutorial_credit_scoring.ipynb
+++ b/examples/tutorial_credit_scoring.ipynb
@@ -56,9 +56,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Load all necessary packages\n",
@@ -87,21 +85,15 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:root:'scores' has no well-defined meaning out of range [0, 1].\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "dataset_orig = GermanDataset(protected_attribute_names=['age'],           # this dataset also contains protected\n",
-    "                                                                          # attribute for \"sex\" which we do not\n",
-    "                                                                          # consider in this evaluation\n",
-    "                             privileged_classes=[lambda x: x >= 25],      # age >=25 is considered privileged\n",
-    "                             features_to_drop=['personal_status', 'sex']) # ignore sex-related attributes\n",
+    "dataset_orig = GermanDataset(\n",
+    "    protected_attribute_names=['age'],           # this dataset also contains protected\n",
+    "                                                 # attribute for \"sex\" which we do not\n",
+    "                                                 # consider in this evaluation\n",
+    "    privileged_classes=[lambda x: x >= 25],      # age >=25 is considered privileged\n",
+    "    features_to_drop=['personal_status', 'sex'] # ignore sex-related attributes\n",
+    ")\n",
     "\n",
     "dataset_orig_train, dataset_orig_test = dataset_orig.split([0.7], shuffle=True)\n",
     "\n",


### PR DESCRIPTION
* shortened lines that wrapped awkwardly when viewed on GitHub in tutorial_credit_scoring.ipynb
* got rid of unnecessary warnings in demo_optim_preproc_adult.ipynb and tutorial_credit_scoring.ipynb