### PR TITLE
Add convenience method to explain all available metrics

### DIFF
--- a/aif360/explainers/metric_text_explainer.py
+++ b/aif360/explainers/metric_text_explainer.py
@@ -6,6 +6,8 @@ from __future__ import unicode_literals
 from aif360.explainers import Explainer
 from aif360.metrics import Metric
 
+from typing import Union
+
 
 class MetricTextExplainer(Explainer):
     """Class for explaining metric values with text.
@@ -29,6 +31,28 @@ class MetricTextExplainer(Explainer):
             self.metric = metric
         else:
             raise TypeError("metric must be a Metric.")
+
+    def explain(self,
+                disp: bool = True) -> Union[None, str]:
+        """Explain everything available for the given metric.
+
+        Args:
+            disp: If true print generated string, else return generated string.
+        """
+
+        # Find intersecting methods/attributes between MetricTextExplainer and provided metric.
+        inter = set(dir(self)).intersection(set(dir(self.metric)))
+
+        # Ignore private and dunder methods
+        metric_methods = [getattr(self, c) for c in inter if c.startswith('_') < 1]
+
+        # Call methods, join to new lines
+        s = "\n".join([f() for f in metric_methods if callable(f)])
+
+        if disp:
+            print(s)
+        else:
+            return s
 
     def accuracy(self, privileged=None):
         if privileged is None:


### PR DESCRIPTION
Hi all,

Firstly, great work on this toolbox - I've been trying it out to present to our lab, and it's impressive how comprehensive it is.

I've made a small method for MetricTextExplainer that might be generally useful. It finds and runs all the available methods for the given metric in one method call (.explain()).

Here's a usage example:

````Python
from aif360.datasets import GermanDataset
from aif360.metrics import BinaryLabelDatasetMetric
from aif360.explainers import MetricTextExplainer

dataset_orig = GermanDataset(protected_attribute_names=['age'],
                             privileged_classes=[lambda x: x >= 25],
                             features_to_drop=['personal_status', 'sex'])

dataset_orig_train, dataset_orig_test = dataset_orig.split([0.7], shuffle=True)

privileged_groups = [{'age': 1}]
unprivileged_groups = [{'age': 0}]

metric_orig_train = BinaryLabelDatasetMetric(dataset_orig_train,
                                             unprivileged_groups=unprivileged_groups,
                                             privileged_groups=privileged_groups)

me = MetricTextExplainer(metric_orig_train)
me.explain()
````

````Number of positive-outcome instances: 490.0
Mean difference (mean label value on privileged instances - mean label value on unprivileged instances): -0.1400608960417573
Consistency (Zemel, et al. 2013): [0.68571429]
Number of negative-outcome instances: 210.0
Disparate impact (probability of favorable outcome for unprivileged instances / probability of favorable outcome for privileged instances): 0.8052026618269812
Number of instances: 700.0
Statistical parity difference (probability of favorable outcome for unprivileged instances - probability of ````favorable outcome for privileged instances): -0.1400608960417573
