### PR TITLE
Added Area under Receiving Operating Characteristic curve 

### DIFF
--- a/aif360/metrics/classification_metric.py
+++ b/aif360/metrics/classification_metric.py
@@ -7,9 +7,8 @@ from itertools import product
 
 import numpy as np
 
-from aif360.metrics import BinaryLabelDatasetMetric
+from aif360.metrics import BinaryLabelDatasetMetric, utils
 from aif360.datasets import BinaryLabelDataset
-from aif360.metrics import utils
 
 class ClassificationMetric(BinaryLabelDatasetMetric):
     """Class for computing metrics based on two BinaryLabelDatasets.

--- a/aif360/metrics/classification_metric.py
+++ b/aif360/metrics/classification_metric.py
@@ -103,7 +103,7 @@ class ClassificationMetric(BinaryLabelDatasetMetric):
             self.dataset.favorable_label, self.dataset.unfavorable_label,
             condition=condition)
 
-    def compute_ROC_metric(self, privileged=None):
+    def compute_ROC(self, privileged=None):
 
         """Compute area under Receiver Operating Characteristic curve.
 

--- a/aif360/metrics/classification_metric.py
+++ b/aif360/metrics/classification_metric.py
@@ -6,11 +6,10 @@ from __future__ import unicode_literals
 from itertools import product
 
 import numpy as np
-import utils
 
 from aif360.metrics import BinaryLabelDatasetMetric
 from aif360.datasets import BinaryLabelDataset
-
+from aif360.metrics import utils
 
 class ClassificationMetric(BinaryLabelDatasetMetric):
     """Class for computing metrics based on two BinaryLabelDatasets.
@@ -105,15 +104,29 @@ class ClassificationMetric(BinaryLabelDatasetMetric):
             self.dataset.favorable_label, self.dataset.unfavorable_label,
             condition=condition)
 
-    def compute_ROC_Metric(self, privileged=None):
+    def compute_ROC_metric(self, privileged=None):
+
+        """Compute area under Receiver Operating Characteristic curve.
+
+        Args:
+            privileged (bool, optional): Boolean prescribing whether to
+                condition this metric on the `privileged_groups`, if `True`, or
+                the `unprivileged_groups`, if `False`. Defaults to `None`
+                meaning this metric is computed over the entire dataset.
+        Returns:
+            list : False positive list at classification thresholds ranging from 0 to 1
+                   True positive list at classification thresholds ranging from 0 to 1
+                   Area under Receiver Operator Characteristic curve
+        """
+
         condition = self._to_condition(privileged)
 
-        utils.compute_ROC(self.dataset.protected_attributes,
-                                    self.dataset.labels, self.classified_dataset.scores,
-                                    self.dataset.instance_weights,
-                                    self.dataset.protected_attribute_names,
-                                    self.dataset.favorable_label, self.dataset.unfavorable_label,
-                                    condition=condition)
+        return utils.compute_ROC(self.dataset.protected_attributes,
+            self.dataset.labels, self.classified_dataset.scores,
+            self.dataset.instance_weights,
+            self.dataset.protected_attribute_names,
+            self.dataset.favorable_label, self.dataset.unfavorable_label,
+            condition=condition)
 
     def num_true_positives(self, privileged=None):
         r"""Return the number of instances in the dataset where both the

--- a/aif360/metrics/classification_metric.py
+++ b/aif360/metrics/classification_metric.py
@@ -103,7 +103,7 @@ class ClassificationMetric(BinaryLabelDatasetMetric):
             self.dataset.favorable_label, self.dataset.unfavorable_label,
             condition=condition)
 
-    def compute_ROC(self, privileged=None):
+    def compute_ROC_metric(self, privileged=None):
 
         """Compute area under Receiver Operating Characteristic curve.
 

--- a/aif360/metrics/classification_metric.py
+++ b/aif360/metrics/classification_metric.py
@@ -6,8 +6,9 @@ from __future__ import unicode_literals
 from itertools import product
 
 import numpy as np
+import utils
 
-from aif360.metrics import BinaryLabelDatasetMetric, utils
+from aif360.metrics import BinaryLabelDatasetMetric
 from aif360.datasets import BinaryLabelDataset
 
 
@@ -103,6 +104,16 @@ class ClassificationMetric(BinaryLabelDatasetMetric):
             self.dataset.protected_attribute_names,
             self.dataset.favorable_label, self.dataset.unfavorable_label,
             condition=condition)
+
+    def compute_ROC_Metric(self, privileged=None):
+        condition = self._to_condition(privileged)
+
+        utils.compute_ROC(self.dataset.protected_attributes,
+                                    self.dataset.labels, self.classified_dataset.scores,
+                                    self.dataset.instance_weights,
+                                    self.dataset.protected_attribute_names,
+                                    self.dataset.favorable_label, self.dataset.unfavorable_label,
+                                    condition=condition)
 
     def num_true_positives(self, privileged=None):
         r"""Return the number of instances in the dataset where both the

--- a/aif360/metrics/utils.py
+++ b/aif360/metrics/utils.py
@@ -189,18 +189,16 @@ def compute_ROC(X, y_true, y_pred, w, feature_names, favorable_label,
     true_positive_matrix /= number_of_positives
     false_positive_maxtrix /= number_of_negatives
 
-    plt.title('Receiver Operating Characteristic')
-    plt.plot(false_positive_maxtrix, true_positive_matrix, 'b')
-    plt.legend(loc='lower right')
-    plt.plot([0, 1], [0, 1], 'r--')
-    plt.xlim([0, 1])
-    plt.ylim([0, 1])
-    plt.ylabel('True Positive Rate')
-    plt.xlabel('False Positive Rate')
+    #calculate AUC using trapezoidal sums
+    height = (np.add([true_positive_matrix[i] for i in range(1,true_positive_matrix.size)],
+                     [true_positive_matrix[x] for x in range(0,true_positive_matrix.size-1)]))
+    height /= 2.
+    width = -np.diff(false_positive_maxtrix)
 
-    plt.show()
+    #calculate AUC
+    auc = np.sum(height*width)
 
-    return false_positive_maxtrix, true_positive_matrix
+    return false_positive_maxtrix, true_positive_matrix, auc
 
 
 

--- a/aif360/metrics/utils.py
+++ b/aif360/metrics/utils.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import numpy as np
+import matplotlib.pyplot as plt
 
 
 def compute_boolean_conditioning_vector(X, feature_names, condition=None):
@@ -125,6 +126,83 @@ def compute_num_TF_PN(X, y_true, y_pred, w, feature_names, favorable_label,
         TN=np.sum(w[np.logical_and(y_true_neg, y_pred_neg)], dtype=np.float64),
         FN=np.sum(w[np.logical_and(y_true_pos, y_pred_neg)], dtype=np.float64)
     )
+
+def compute_ROC(X, y_true, y_pred, w, feature_names, favorable_label,
+                      unfavorable_label, condition = None, resolution = 0.01) :
+
+    """Calculate Area under Receiver Operating Characteristic Curve.
+
+    Args:
+        X (numpy.ndarray): Dataset features.
+        y_true (numpy.ndarray): True label vector.
+        y_pred (numpy.ndarray): Predicted label vector.
+        w (numpy.ndarray): Instance weight vector - the true and predicted
+            datasets are supposed to have same instance level weights.
+        feature_names (list): names of the features.
+        favorable_label (float): Value of favorable/positive label.
+        unfavorable_label (float): Value of unfavorable/negative label.
+        condition (list(dict)): Same format as
+            :func:`compute_boolean_conditioning_vector`.
+        resolution : steps to increment classification threshold
+
+    Returns:
+        False negative rate matrix for given classification thresholds
+        True positive rate matrix for given classification thresholds
+        Area under Receiver Operating Characteristic Curve
+    """
+
+    #condition if necessary
+    condition_vector = compute_boolean_conditioning_vector(X, feature_names, condition=condition)
+
+    #range of values for threshold
+    rangeArr = np.arange(np.minimum(favorable_label, unfavorable_label),
+                      np.maximum(favorable_label, unfavorable_label),
+                      resolution)
+
+    # avoid broadcasts
+    y_true = y_true.ravel()
+    y_predicted = y_pred.ravel()
+
+    #true positives and negatives
+    y_true_positive = (y_true == favorable_label)
+    y_true_negative = (y_true == unfavorable_label)
+
+    #calculate amount of positive and negative instances
+    number_of_positives = np.sum(np.logical_and(y_true_positive, condition_vector))
+    number_of_negatives = np.sum(np.logical_and(y_true_negative, condition_vector))
+
+    #hold true and false positives at different thresholds
+    true_positive_matrix = []
+    false_positive_maxtrix = []
+
+    #calculate thresholds
+    for threshold in rangeArr:
+
+        #calculate new predicted positives for the threshold
+        y_pred_positive = np.logical_and(y_predicted > threshold, condition_vector)
+
+        #append to the matrix for graphing
+        true_positive_matrix.append(np.sum(w[np.logical_and(y_true_positive, y_pred_positive)], dtype=np.float64))
+        false_positive_maxtrix.append(np.sum(w[np.logical_and(y_true_negative, y_pred_positive)],dtype=np.float64))
+
+    #devide by number of positive and negative instances to get rates
+    true_positive_matrix /= number_of_positives
+    false_positive_maxtrix /= number_of_negatives
+
+    plt.title('Receiver Operating Characteristic')
+    plt.plot(false_positive_maxtrix, true_positive_matrix, 'b')
+    plt.legend(loc='lower right')
+    plt.plot([0, 1], [0, 1], 'r--')
+    plt.xlim([0, 1])
+    plt.ylim([0, 1])
+    plt.ylabel('True Positive Rate')
+    plt.xlabel('False Positive Rate')
+
+    plt.show()
+
+    return false_positive_maxtrix, true_positive_matrix
+
+
 
 def compute_num_gen_TF_PN(X, y_true, y_score, w, feature_names, favorable_label,
                     unfavorable_label, condition=None):

--- a/tests/test_classification_metric.py
+++ b/tests/test_classification_metric.py
@@ -31,9 +31,6 @@ def test_generalized_entropy_index():
         protected_attribute_names=['feat'])
     cm = ClassificationMetric(bld, bld2)
 
-    print("__TESTING ROC___")
-    cm.compute_ROC_Metric()
-
     assert cm.generalized_entropy_index() == 0.2
 
     pred = data.copy()
@@ -44,8 +41,6 @@ def test_generalized_entropy_index():
     cm = ClassificationMetric(bld, bld2)
 
     assert cm.generalized_entropy_index() == 0.3
-
-test_generalized_entropy_index()
 
 def test_theil_index():
     data = np.array([[0, 1],

--- a/tests/test_classification_metric.py
+++ b/tests/test_classification_metric.py
@@ -7,8 +7,7 @@ import numpy as np
 import pandas as pd
 
 from aif360.datasets import BinaryLabelDataset
-from aif360.metrics import ClassificationMetric
-
+from aif360.metrics import classification_metric
 
 def test_generalized_entropy_index():
     data = np.array([[0, 1],
@@ -32,6 +31,9 @@ def test_generalized_entropy_index():
         protected_attribute_names=['feat'])
     cm = ClassificationMetric(bld, bld2)
 
+    print("__TESTING ROC___")
+    cm.compute_ROC_Metric()
+
     assert cm.generalized_entropy_index() == 0.2
 
     pred = data.copy()
@@ -42,6 +44,8 @@ def test_generalized_entropy_index():
     cm = ClassificationMetric(bld, bld2)
 
     assert cm.generalized_entropy_index() == 0.3
+
+test_generalized_entropy_index()
 
 def test_theil_index():
     data = np.array([[0, 1],


### PR DESCRIPTION
Hello,
       While working on a project for my group I noticed that IBM's AIF360 library did not have a way to measure area under the receiver operating characteristic curve. This is a metric I've found useful in the past and thought adding it to the library out of the box would be beneficial. 
        I was able to achieve this without importing any extra libraries. The "compute_ROC" function under metrics/utils.py takes in essentially the same parameters as "compute_num_TF_PN" . This function returns the false positive list, true positive list under different thresholds and area under the Receiver Operating Characteristic curve.
       Under metrics/classification_metric.py I added "compute_ROC_metric", which takes the privileged condition as a parameter and returns the same three variables as "compute_ROC".
       I tested this using the desperate impact remover example and received similar values to sklearn's library.
Thank you,
 Connor Hofenbitzer