### PR TITLE
Remove orange3 from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,4 @@ numba==0.42.0
 tensorflow>=1.13.1,<2
 networkx==1.11
 BlackBoxAuditing
-Orange3>=3.3.5,<=3.7.1
 lime


### PR DESCRIPTION
No longer required by BlackBoxAuditing. Should fix some installation problems people were having with Python 3.7. Also, resolves #112 