### PR TITLE
Differential fairness metric

### DIFF
--- a/aif360/metrics/binary_label_dataset_metric.py
+++ b/aif360/metrics/binary_label_dataset_metric.py
@@ -1,5 +1,3 @@
-from itertools import product
-
 import numpy as np
 from sklearn.neighbors import NearestNeighbors
 
@@ -144,6 +142,25 @@ class BinaryLabelDatasetMetric(DatasetMetric):
 
     def smoothed_empirical_differential_fairness(self):
         """Compute smoothed EDF from [#foulds18]_.
+
+        Examples:
+            To use with non-binary protected attributes, the column must be
+            converted to ordinal:
+            
+            >>> mapping = {'Black': 0, 'White': 1, 'Asian-Pac-Islander': 2,
+            ... 'Amer-Indian-Eskimo': 3, 'Other': 4}
+            >>> def map_race(df):
+            ...     df['race-num'] = df.race.map(mapping)
+            ...     return df
+            ...
+            >>> adult = AdultDataset(protected_attribute_names=['sex',
+            ... 'race-num'], privileged_classes=[['Male'], [1]],
+            ... categorical_features=['workclass', 'education',
+            ... 'marital-status', 'occupation', 'relationship',
+            ... 'native-country', 'race'], custom_preprocessing=map_race)
+            >>> metric = BinaryLabelDatasetMetric(adult)
+            >>> metric.smoothed_empirical_differential_fairness()
+            1.7547611985549287
 
         References:
             .. [#foulds18] J. R. Foulds, R. Islam, K. N. Keya, and S. Pan,

--- a/aif360/metrics/binary_label_dataset_metric.py
+++ b/aif360/metrics/binary_label_dataset_metric.py
@@ -140,8 +140,43 @@ class BinaryLabelDatasetMetric(DatasetMetric):
 
         return consistency
 
-    def smoothed_empirical_differential_fairness(self):
-        """Compute smoothed EDF from [#foulds18]_.
+    def _smoothed_base_rates(self, labels, concentration=1.0):
+        """Dirichlet-smoothed base rates for each intersecting group in the
+        dataset.
+        """
+        # Dirichlet smoothing parameters
+        if concentration < 0:
+            raise ValueError("Concentration parameter must be non-negative.")
+        num_classes = 2  # binary label dataset
+        dirichlet_alpha = concentration / num_classes
+
+        # compute counts for all intersecting groups, e.g. black-women, white-man, etc
+        intersect_groups = np.unique(self.dataset.protected_attributes, axis=0)
+        num_intersects = len(intersect_groups)
+        counts_pos = np.zeros(num_intersects)
+        counts_total = np.zeros(num_intersects)
+        for i in range(num_intersects):
+            condition = [dict(zip(self.dataset.protected_attribute_names,
+                                  intersect_groups[i]))]
+            counts_total[i] = utils.compute_num_instances(
+                    self.dataset.protected_attributes,
+                    self.dataset.instance_weights,
+                    self.dataset.protected_attribute_names, condition=condition)
+            counts_pos[i] = utils.compute_num_pos_neg(
+                    self.dataset.protected_attributes, labels,
+                    self.dataset.instance_weights,
+                    self.dataset.protected_attribute_names,
+                    self.dataset.favorable_label, condition=condition)
+
+        # probability of y given S (p(y=1|S))
+        return (counts_pos + dirichlet_alpha) / (counts_total + concentration)
+
+    def smoothed_empirical_differential_fairness(self, concentration=1.0):
+        """Smoothed EDF from [#foulds18]_.
+
+        Args:
+            concentration (float, optional): Concentration parameter for
+                Dirichlet smoothing. Must be non-negative.
 
         Examples:
             To use with non-binary protected attributes, the column must be
@@ -167,45 +202,17 @@ class BinaryLabelDatasetMetric(DatasetMetric):
                "An Intersectional Definition of Fairness," arXiv preprint
                arXiv:1807.08362, 2018.
         """
-        # Dirichlet smoothing parameters
-        num_classes = 2  # binary label dataset
-        concentration_parameter = 1.0
-        dirichlet_alpha = concentration_parameter / num_classes
-
-        # compute counts for all intersecting groups, e.g. black-women, white-man etc
-        intersect_groups = np.unique(self.dataset.protected_attributes, axis=0)
-        num_intersects = len(intersect_groups)
-        counts_pos = np.zeros(num_intersects)
-        counts_total = np.zeros(num_intersects)
-        for i in range(num_intersects):
-            condition = [dict(zip(self.dataset.protected_attribute_names,
-                                  intersect_groups[i]))]
-            counts_total[i] = utils.compute_num_instances(
-                    self.dataset.protected_attributes,
-                    self.dataset.instance_weights,
-                    self.dataset.protected_attribute_names, condition=condition)
-            counts_pos[i] = utils.compute_num_pos_neg(
-                    self.dataset.protected_attributes, self.dataset.labels,
-                    self.dataset.instance_weights,
-                    self.dataset.protected_attribute_names,
-                    self.dataset.favorable_label, condition=condition)
-
-        # probability of y given S (p(y=1|S))
-        smoothed_base_rate = ((counts_pos + dirichlet_alpha)
-                            / (counts_total + concentration_parameter))
+        sbr = self._smoothed_base_rates(self.dataset.labels, concentration)
 
         def pos_ratio(i, j):
-            return abs(np.log(smoothed_base_rate[i])
-                     - np.log(smoothed_base_rate[j]))
+            return abs(np.log(sbr[i]) - np.log(sbr[j]))
 
         def neg_ratio(i, j):
-            return abs(np.log(1 - smoothed_base_rate[i])
-                     - np.log(1 - smoothed_base_rate[j]))
+            return abs(np.log(1 - sbr[i]) - np.log(1 - sbr[j]))
 
         # overall DF of the mechanism
         return max(max(pos_ratio(i, j), neg_ratio(i, j))
-                   for i in range(num_intersects) for j in range(num_intersects)
-                   if i != j)
+                   for i in range(len(sbr)) for j in range(len(sbr)) if i != j)
 
     # ============================== ALIASES ===================================
     def mean_difference(self):

--- a/aif360/metrics/binary_label_dataset_metric.py
+++ b/aif360/metrics/binary_label_dataset_metric.py
@@ -1,3 +1,5 @@
+from itertools import product
+
 import numpy as np
 from sklearn.neighbors import NearestNeighbors
 
@@ -139,6 +141,54 @@ class BinaryLabelDatasetMetric(DatasetMetric):
         consistency = 1.0 - consistency/num_samples
 
         return consistency
+
+    def smoothed_empirical_differential_fairness(self):
+        """Compute smoothed EDF from [#foulds18]_.
+
+        References:
+            .. [#foulds18] J. R. Foulds, R. Islam, K. N. Keya, and S. Pan,
+               "An Intersectional Definition of Fairness," arXiv preprint
+               arXiv:1807.08362, 2018.
+        """
+        # Dirichlet smoothing parameters
+        num_classes = 2  # binary label dataset
+        concentration_parameter = 1.0
+        dirichlet_alpha = concentration_parameter / num_classes
+
+        # compute counts for all intersecting groups, e.g. black-women, white-man etc
+        intersect_groups = np.unique(self.dataset.protected_attributes, axis=0)
+        num_intersects = len(intersect_groups)
+        counts_pos = np.zeros(num_intersects)
+        counts_total = np.zeros(num_intersects)
+        for i in range(num_intersects):
+            condition = [dict(zip(self.dataset.protected_attribute_names,
+                                  intersect_groups[i]))]
+            counts_total[i] = utils.compute_num_instances(
+                    self.dataset.protected_attributes,
+                    self.dataset.instance_weights,
+                    self.dataset.protected_attribute_names, condition=condition)
+            counts_pos[i] = utils.compute_num_pos_neg(
+                    self.dataset.protected_attributes, self.dataset.labels,
+                    self.dataset.instance_weights,
+                    self.dataset.protected_attribute_names,
+                    self.dataset.favorable_label, condition=condition)
+
+        # probability of y given S (p(y=1|S))
+        smoothed_base_rate = ((counts_pos + dirichlet_alpha)
+                            / (counts_total + concentration_parameter))
+
+        def pos_ratio(i, j):
+            return abs(np.log(smoothed_base_rate[i])
+                     - np.log(smoothed_base_rate[j]))
+
+        def neg_ratio(i, j):
+            return abs(np.log(1 - smoothed_base_rate[i])
+                     - np.log(1 - smoothed_base_rate[j]))
+
+        # overall DF of the mechanism
+        return max(max(pos_ratio(i, j), neg_ratio(i, j))
+                   for i in range(num_intersects) for j in range(num_intersects)
+                   if i != j)
 
     # ============================== ALIASES ===================================
     def mean_difference(self):

--- a/tests/test_differential_fairness.py
+++ b/tests/test_differential_fairness.py
@@ -1,0 +1,30 @@
+import pandas as pd
+from sklearn.preprocessing import StandardScaler
+from sklearn.linear_model import LogisticRegression
+
+from aif360.datasets import AdultDataset
+from aif360.metrics import BinaryLabelDatasetMetric
+
+ad = AdultDataset(protected_attribute_names=['race', 'sex', 'native-country'],
+                  privileged_classes=[['White'], ['Male'], ['United-States']],
+                  categorical_features=['workclass', 'education',
+                          'marital-status', 'occupation', 'relationship'],
+                  custom_preprocessing=lambda df: df.fillna('Unknown'))
+adult_train, adult_test = ad.split([32561], shuffle=False)
+
+def test_epsilon_dataset_binary_groups():
+    dataset_metric = BinaryLabelDatasetMetric(adult_test)
+    eps_data = dataset_metric.smoothed_empirical_differential_fairness()
+    assert eps_data == 1.53679014653623  # verified with reference implementation
+
+def test_epsilon_classifier_binary_groups():
+    scaler = StandardScaler()
+    X = scaler.fit_transform(adult_train.features)
+    test_X = scaler.transform(adult_test.features)
+    clf = LogisticRegression(C=1.0, random_state=0, solver='liblinear')
+
+    adult_pred = adult_test.copy()
+    adult_pred.labels = clf.fit(X, adult_train.labels.ravel()).predict(test_X)
+    classifier_metric = BinaryLabelDatasetMetric(adult_pred)
+    eps_clf = classifier_metric.smoothed_empirical_differential_fairness()
+    assert eps_clf == 1.6434003346776307  # verified with reference implementation


### PR DESCRIPTION
Credit to Rashidul Islam for the reference implementation.

Adds `smoothed_empirical_differential_fairness()` to `BinaryLabelDatasetMetric`. This will use all protected attributes included in the dataset to compute the intersectional groups present. To ensure multi-class (non-binary) protected attributes are correctly considered, they should be mapped to integers in `custom_preprocessing`, e.g.:
```
def custom_preprocessing(df):
    df.race = df.race.map({'Black': 0, 'White': 1, 'Asian-Pac-Islander': 2,
                           'Amer-Indian-Eskimo': 3, 'Other': 4})
    return df
```
see examples in docs for more details.