### PR TITLE
Fix typo in mean_difference message

### DIFF
--- a/aif360/explainers/metric_text_explainer.py
+++ b/aif360/explainers/metric_text_explainer.py
@@ -184,8 +184,8 @@ class MetricTextExplainer(Explainer):
             self.metric.generalized_entropy_index(alpha=alpha))
 
     def mean_difference(self):
-        return ("Mean difference (mean label value on privileged instances - "
-                "mean label value on unprivileged instances): {}".format(
+        return ("Mean difference (mean label value on unprivileged instances - "
+                "mean label value on privileged instances): {}".format(
                     self.metric.mean_difference()))
 
     def negative_predictive_value(self, privileged=None):


### PR DESCRIPTION
This PR swaps the privileged and unprivileged terms in the messaging of `MetricTextExplainer.mean_difference()`.

If I understand correctly, the calculation for `mean_difference()` is unprivileged instances - privileged instances as seen here: https://github.com/IBM/AIF360/blob/9304749698a50ff3c2118619c627e49df626ecf3/aif360/metrics/dataset_metric.py#L77
