### PR TITLE
Fallback to HTTP instead of FTP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python: "3.6"
 env:
   global:
     - UCI_HTTPS_URL="https://archive.ics.uci.edu/ml/machine-learning-databases"
-    - UCI_FTP_URL="ftp://ftp.ics.uci.edu/pub/machine-learning-databases"
 
 branches:
   only:
@@ -14,11 +13,11 @@ branches:
 install:
   - pip install -r requirements.txt
   - pip install flake8
-  - if ! wget ${UCI_HTTPS_URL}/adult/adult.data -P aif360/data/raw/adult/ ; then wget ${UCI_FTP_URL}/adult/adult.data -P aif360/data/raw/adult/ ; fi
-  - if ! wget ${UCI_HTTPS_URL}/adult/adult.test -P aif360/data/raw/adult/ ; then wget ${UCI_FTP_URL}/adult/adult.test -P aif360/data/raw/adult/; fi
-  - if ! wget ${UCI_HTTPS_URL}/adult/adult.names -P aif360/data/raw/adult/ ; then wget ${UCI_FTP_URL}/adult/adult.names -P aif360/data/raw/adult/; fi
-  - if ! wget ${UCI_HTTPS_URL}/statlog/german/german.data -P aif360/data/raw/german/ ; then wget ${UCI_FTP_URL}/statlog/german/german.data -P aif360/data/raw/german/; fi
-  - if ! wget ${UCI_HTTPS_URL}/statlog/german/german.doc -P aif360/data/raw/german/ ; then wget ${UCI_FTP_URL}/statlog/german/german.doc -P aif360/data/raw/german/; fi
+  - if ! wget ${UCI_HTTPS_URL}/adult/adult.data -P aif360/data/raw/adult/ ; then wget ${UCI_HTTPS_URL}/adult/adult.data --no-check-certificate -P aif360/data/raw/adult/ ; fi
+  - if ! wget ${UCI_HTTPS_URL}/adult/adult.test -P aif360/data/raw/adult/ ; then wget ${UCI_HTTPS_URL}/adult/adult.test --no-check-certificate -P aif360/data/raw/adult/; fi
+  - if ! wget ${UCI_HTTPS_URL}/adult/adult.names -P aif360/data/raw/adult/ ; then wget ${UCI_HTTPS_URL}/adult/adult.names --no-check-certificate -P aif360/data/raw/adult/; fi
+  - if ! wget ${UCI_HTTPS_URL}/statlog/german/german.data -P aif360/data/raw/german/ ; then wget ${UCI_HTTPS_URL}/statlog/german/german.data --no-check-certificate -P aif360/data/raw/german/; fi
+  - if ! wget ${UCI_HTTPS_URL}/statlog/german/german.doc -P aif360/data/raw/german/ ; then wget ${UCI_HTTPS_URL}/statlog/german/german.doc --no-check-certificate -P aif360/data/raw/german/; fi
   - wget https://raw.githubusercontent.com/propublica/compas-analysis/master/compas-scores-two-years.csv -P aif360/data/raw/compas/
 
 before_script:


### PR DESCRIPTION
UCI repository's HTTPS certificate has expired so fall back to HTTP

FTP no longer works on travis servers (see: https://blog.travis-ci.com/2018-07-23-the-tale-of-ftp-at-travis-ci)