### PR TITLE
add score attribute to fair data set

### DIFF
--- a/aif360/algorithms/preprocessing/lfr.py
+++ b/aif360/algorithms/preprocessing/lfr.py
@@ -14,12 +14,10 @@ class LFR(Transformer):
     """Learning fair representations is a pre-processing technique that finds a
     latent representation which encodes the data well but obfuscates information
     about protected attributes [2]_.
-
     References:
         .. [2] R. Zemel, Y. Wu, K. Swersky, T. Pitassi, and C. Dwork,  "Learning
            Fair Representations." International Conference on Machine Learning,
            2013.
-
     Based on code from https://github.com/zjelveh/learning-fair-representations
     """
 
@@ -73,7 +71,6 @@ class LFR(Transformer):
 
     def fit(self, dataset, **kwargs):
         """Compute the transformation parameters that leads to fair representations.
-
         Args:
             dataset (BinaryLabelDataset): Dataset containing true labels.
         Returns:
@@ -112,7 +109,6 @@ class LFR(Transformer):
 
     def transform(self, dataset, threshold=0.5, **kwargs):
         """Transform the dataset using learned model parameters.
-
         Args:
             dataset (BinaryLabelDataset): Dataset containing labels that needs to be transformed.
             threshold(float, optional): threshold parameter used for binary label prediction.
@@ -170,14 +166,15 @@ class LFR(Transformer):
             [-1, 1])
         transformed_labels[nonsensitive_idx] = np.reshape(y_hat_nonsensitive,
             [-1, 1])
-        transformed_labels = (np.array(transformed_labels) > threshold).astype(np.float64)
+        transformed_bin_labels = (np.array(transformed_labels) > threshold).astype(np.float64)
 
         # Mutated, fairer dataset with new labels
         dataset_new = dataset.copy(deepcopy=True)
         dataset_new.features = transformed_features
-        dataset_new.labels = transformed_labels
+        dataset_new.labels = transformed_bin_labels
+        dataset_new.scores = np.array(transformed_labels)
 
-        return dataset_new
+        return dataset_new    
 
     def fit_transform(self, dataset, seed=None):
         """fit and transform methods sequentially"""


### PR DESCRIPTION
Prediction scores are computed as part of Zemel's lfr algorithm. However, so far the `dataset_new` class does not allow for outputting those scores, but only for the resulting binary predicted labels. In this minor change we added a `dataset_new.scores` attribute which enables scores output. This is analogous to already existing code, see, e.g., in the adversarial debiasing code: https://github.com/IBM/AIF360/blob/master/aif360/algorithms/inprocessing/adversarial_debiasing.py#L260